### PR TITLE
Support for alternative bundle file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,32 @@ To make life a little easier during development make sure that the following are
 
 ```javascript
 {
-  "{lib_name}": ["{desired_version}"]
+  "{lib_name}": {
+    // Available package versions
+    "versions": [
+      "{desired_version}"
+    ],
+
+    // (optional) Documentation's or repository's URL
+    "docs-url": "{documentation_or_repository_url}",
+
+    // (optional) As a default, the homepage will point to
+    // a package's bundle's index.js. If your package main
+    // bundle's name is different, set it here (see the AWS
+    // package for instance).
+    "bundle-filename": "{index.js}"
 }
 
 // Example result
 {
-  "awesome-lib": ["2.0.3"]
+  "awesome-lib": {
+    "versions": [
+      "2.0.3",
+      "2.1.2"
+    ],
+    "docs-url": "https://github.com/example/jslib",
+    "bundle-filename": "main.js"
+  }
 }
 ```
 

--- a/lib/index.html
+++ b/lib/index.html
@@ -628,7 +628,7 @@ export default function() {
       <td><a href="https://www.npmjs.com/package/kahwah">https://www.npmjs.com/package/kahwah</a></td>
     </tr><tr>
       <td>aws</td>
-      <td><a target="_blank" href="https://jslib.k6.io/aws/0.1.0/index.js">0.1.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.3.0/index.js">0.3.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.4.0/index.js">0.4.0</a></td>
+      <td><a target="_blank" href="https://jslib.k6.io/aws/0.1.0/index.js">0.1.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.3.0/aws.js">0.3.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.4.0/aws.js">0.4.0</a></td>
       <td><a href="https://github.com/grafana/k6-jslib-aws">https://github.com/grafana/k6-jslib-aws</a></td>
     </tr>
     </table>

--- a/static/index-template.js
+++ b/static/index-template.js
@@ -18,8 +18,9 @@ const versionsTable = () => {
   const supported = require('../supported.json');
   const trs = Object.entries(supported)
     .map(([name, lib]) => {
+      const bundleFilename = lib['bundle-filename'] ?? 'index.js';
       const versionLinks = lib.versions
-        .map(version => createLink(name, version, 'index.js'))
+        .map(version => createLink(name, version, bundleFilename))
         .join(', ');
         docsLink = lib['docs-url'] ? `<a href="${lib['docs-url']}">${lib['docs-url']}</a>`: "";
       return `<tr>

--- a/supported.json
+++ b/supported.json
@@ -93,6 +93,7 @@
       "0.3.0",
       "0.4.0"
     ],
+    "bundle-filename": "aws.js",
     "docs-url": "https://github.com/grafana/k6-jslib-aws"
   }
 }


### PR DESCRIPTION
As of today, it was only possible to have the jslib.k6.io page point to
a package's bundle file named `index.js`. With the introduction of the
AWS package, this became an issue as its main bundle is called `aws.js`
and it also exposes a variety of others.

This commit allows using the `bundle-filename` property inside the
`supported.json` file to define the name of the bundle file.