### PR TITLE
Fix aws 0.1.0 link

### DIFF
--- a/lib/index.html
+++ b/lib/index.html
@@ -628,7 +628,7 @@ export default function() {
       <td><a href="https://www.npmjs.com/package/kahwah">https://www.npmjs.com/package/kahwah</a></td>
     </tr><tr>
       <td>aws</td>
-      <td><a target="_blank" href="https://jslib.k6.io/aws/0.1.0/aws.js">0.1.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.3.0/aws.js">0.3.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.4.0/aws.js">0.4.0</a></td>
+      <td><a target="_blank" href="https://jslib.k6.io/aws/0.1.0/index.js">0.1.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.3.0/aws.js">0.3.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.4.0/aws.js">0.4.0</a></td>
       <td><a href="https://github.com/grafana/k6-jslib-aws">https://github.com/grafana/k6-jslib-aws</a></td>
     </tr>
     </table>


### PR DESCRIPTION
Missed the aws link in the last PR. https://jslib.k6.io/aws/0.1.0/aws.js -> https://jslib.k6.io/aws/0.1.0/index.js