### PR TITLE
Import k6-docs style rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+.cache/
+lib/
+node_modules/

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,91 @@
+{
+    "parserOptions": {
+      "ecmaFeatures": {
+        "jsx": true
+      },
+      "ecmaVersion": 2020,
+      "sourceType": "module"
+    },
+    "extends": ["airbnb", "prettier"],
+    "plugins": ["react", "prettier"],
+    "env": {
+      "browser": true,
+      "node": true
+    },
+    "rules": {
+      "prettier/prettier": ["error"],
+      "arrow-body-style": "warn",
+      "camelcase": 0,
+      "object-curly-newline": 0,
+      "operator-linebreak": 0,
+      "no-shadow": 0,
+      "max-len": [2, 120],
+      "no-underscore-dangle": "off",
+      "react/prop-types": 0,
+      "react/function-component-definition": 0,
+      "react/no-unstable-nested-components": 0,
+      "react/jsx-curly-brace-presence": [
+        2,
+        {
+          "props": "ignore",
+          "children": "never"
+        }
+      ],
+      "react/jsx-tag-spacing": [
+        2,
+        {
+          "closingSlash": "never",
+          "beforeSelfClosing": "always",
+          "afterOpening": "allow-multiline",
+          "beforeClosing": "never"
+        }
+      ],
+      "react/jsx-filename-extension": [
+        2,
+        {
+          "extensions": [".js"]
+        }
+      ],
+      "react/no-array-index-key": 0,
+      "react/jsx-one-expression-per-line": 0,
+      "react/jsx-props-no-spreading": 0,
+      "react/jsx-wrap-multilines": 0,
+      "import/no-extraneous-dependencies": [
+        "warn",
+        { "devDependencies": false, "peerDependencies": true }
+      ],
+      "import/order": [
+        "warn",
+        {
+          "alphabetize": {
+            "order": "asc" /* sort in ascending order. Options: ['ignore', 'asc', 'desc'] */,
+            "caseInsensitive": true /* ignore case. Options: [true, false] */
+          },
+          "newlines-between": "always"
+        }
+      ],
+      "import/no-unresolved": [
+        2,
+        {
+          "ignore": [
+            "components",
+            "hooks",
+            "images",
+            "layouts",
+            "pages",
+            "styles",
+            "svg",
+            "templates",
+            "utils",
+            "contexts",
+            "i18n",
+            "data"
+          ]
+        }
+      ],
+      "import/prefer-default-export": 0,
+      "jsx-a11y/html-has-lang": 0, // We use react-helmet for that
+      "jsx-a11y/control-has-associated-label": 0
+    }
+  }
+  

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+.cache/
+lib/
+node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/scripts/add-to-supported.js
+++ b/scripts/add-to-supported.js
@@ -1,13 +1,12 @@
-const fs = require('fs');
-const supported = require('../supported.json');
-const pkgName = process.argv.slice(-1)[0];
-
+const fs = require('fs')
+const supported = require('../supported.json')
+const pkgName = process.argv.slice(-1)[0]
 
 if (!supported.hasOwnProperty(pkgName)) {
   const updated = {
     ...supported,
-    [pkgName]: []
-  };
+    [pkgName]: [],
+  }
 
-  fs.writeFileSync("./supported.json", JSON.stringify(updated, null, 2));
+  fs.writeFileSync('./supported.json', JSON.stringify(updated, null, 2))
 }

--- a/scripts/copy-libs.js
+++ b/scripts/copy-libs.js
@@ -1,67 +1,65 @@
 #!/usr/bin/env node
 
-const path = require('path');
-const supported = require('../supported.json');
-const fs = require('fs');
+const path = require('path')
+const supported = require('../supported.json')
+const fs = require('fs')
 const appDir = path.resolve(__dirname, `../`)
 
 function getPkgMeta(pkgName) {
-  const modulePackage = `${appDir}/node_modules/${pkgName}/package.json`;
+  const modulePackage = `${appDir}/node_modules/${pkgName}/package.json`
   if (!fs.existsSync(modulePackage)) {
-    return null;
+    return null
   }
 
-  const packageJSON = require(`${appDir}/node_modules/${pkgName}/package.json`);
-  const { version, browser, main } = packageJSON;
+  const packageJSON = require(`${appDir}/node_modules/${pkgName}/package.json`)
+  const { version, browser, main } = packageJSON
 
   if (!browser && !main) {
     throw new Error(`Could not locate entry point for lib name: ${pkgName}`)
   }
 
-  let modulePath = path.resolve(__dirname, `../node_modules/${pkgName}/`, main || browser);
-  if (!modulePath.includes(".js")) {
-    modulePath = modulePath + ".js";
+  let modulePath = path.resolve(__dirname, `../node_modules/${pkgName}/`, main || browser)
+  if (!modulePath.includes('.js')) {
+    modulePath = modulePath + '.js'
   }
 
   return {
     version,
-    main: modulePath
+    main: modulePath,
   }
 }
-
 
 function main() {
-  const packages = Object.keys(supported);
-  const result = {};
-  const supportedUpdated = {...supported};
+  const packages = Object.keys(supported)
+  const result = {}
+  const supportedUpdated = { ...supported }
 
-  packages.forEach(name => {
-    const pkg = getPkgMeta(name);
+  packages.forEach((name) => {
+    const pkg = getPkgMeta(name)
     if (pkg) {
       if (!supported[name].hasOwnProperty(pkg.version)) {
-        result[name] = pkg;
+        result[name] = pkg
       } else if (!fs.existsSync(`${appDir}/lib/${name}/${pkg.version}`)) {
-        result[name] = pkg;
+        result[name] = pkg
       }
     }
-  });
+  })
 
   if (Object.keys(result).length > 0) {
-    console.log('\n\nFollowing will be added to lib: ');
-    console.table(result);
+    console.log('\n\nFollowing will be added to lib: ')
+    console.table(result)
 
     Object.entries(result).forEach(([name, pkg]) => {
-      const path = `${appDir}/lib/${name}/${pkg.version}`;
-      fs.mkdirSync(path, { recursive: true });
+      const path = `${appDir}/lib/${name}/${pkg.version}`
+      fs.mkdirSync(path, { recursive: true })
 
-      fs.copyFileSync(pkg.main, `${path}/index.js`);
+      fs.copyFileSync(pkg.main, `${path}/index.js`)
 
-      supportedUpdated[name].push(pkg.version);
-    });
+      supportedUpdated[name].push(pkg.version)
+    })
 
-    fs.writeFileSync(`${appDir}/supported.json`, JSON.stringify(supportedUpdated, null, 2));
+    fs.writeFileSync(`${appDir}/supported.json`, JSON.stringify(supportedUpdated, null, 2))
   }
 }
 
-
-main();
+main()

--- a/scripts/create-base64-font.js
+++ b/scripts/create-base64-font.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('fs')
+const path = require('path')
 const fontDirectory = path.resolve(__dirname, '../static/fonts')
 
 const supportedFormats = [
@@ -11,18 +11,15 @@ const supportedFormats = [
 
 function getBase64FontSrc(filename, format) {
   if (!format) {
-    throw new Error('Format was not specified');
+    throw new Error('Format was not specified')
   }
   if (!fs.existsSync(filename)) {
-    throw new Error(`Font filename does not exist (${filename})`);
+    throw new Error(`Font filename does not exist (${filename})`)
   }
 
-  const encodedFont = fs.readFileSync(
-    filename,
-    { encoding: 'base64' },
-  );
+  const encodedFont = fs.readFileSync(filename, { encoding: 'base64' })
 
-  return `url(data:font/${format};charset=utf-8;base64,${encodedFont}) format('${format}')`;
+  return `url(data:font/${format};charset=utf-8;base64,${encodedFont}) format('${format}')`
 }
 
 /**
@@ -31,18 +28,15 @@ function getBase64FontSrc(filename, format) {
  * @returns {string}
  */
 function createBase64Font(filename) {
-  const bulk = [];
+  const bulk = []
   supportedFormats.forEach((formatOptions) => {
-    const formatFilename = `${fontDirectory}/${filename}.${formatOptions.extension}`;
+    const formatFilename = `${fontDirectory}/${filename}.${formatOptions.extension}`
     if (fs.existsSync(formatFilename)) {
-      bulk.push([
-        formatFilename,
-        formatOptions.name,
-      ]);
+      bulk.push([formatFilename, formatOptions.name])
     }
-  });
+  })
 
-  return bulk.map(([fontFilename, format]) => getBase64FontSrc(fontFilename, format)).join(',\n');
+  return bulk.map(([fontFilename, format]) => getBase64FontSrc(fontFilename, format)).join(',\n')
 }
 
-module.exports = createBase64Font;
+module.exports = createBase64Font

--- a/scripts/generate-homepage.js
+++ b/scripts/generate-homepage.js
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
-const fs = require("fs");
-const { renderToString } = require("../static/index-template");
-
+const fs = require('fs')
+const { renderToString } = require('../static/index-template')
 
 function main() {
-  fs.writeFileSync('./lib/index.html', renderToString());
-  fs.copyFileSync('./static/favicon.ico', './lib/favicon.ico');
+  fs.writeFileSync('./lib/index.html', renderToString())
+  fs.copyFileSync('./static/favicon.ico', './lib/favicon.ico')
 
-  console.log("New index.html generated");
+  console.log('New index.html generated')
 }
 
-main();
+main()

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,27 +1,25 @@
-const http = require("http");
-const fs = require("fs");
+const http = require('http')
+const fs = require('fs')
 
-const hostname = "127.0.0.1";
-const port = 3000;
-
+const hostname = '127.0.0.1'
+const port = 3000
 
 process.once('SIGUSR2', function () {
-  process.kill(process.pid, 'SIGUSR2');
-});
+  process.kill(process.pid, 'SIGUSR2')
+})
 
-
-fs.readFile("./lib/index.html", function(err, html) {
+fs.readFile('./lib/index.html', function (err, html) {
   if (err) {
-    throw err;
+    throw err
   }
 
   const server = http
-    .createServer(function(request, response) {
-      response.writeHeader(200, { "Content-Type": "text/html" });
-      response.write(html);
-      response.end();
+    .createServer(function (request, response) {
+      response.writeHeader(200, { 'Content-Type': 'text/html' })
+      response.write(html)
+      response.end()
     })
     .listen(port, hostname, () => {
-      console.log(`Server running at http://${hostname}:${port}/`);
-    });
-});
+      console.log(`Server running at http://${hostname}:${port}/`)
+    })
+})

--- a/static/examples/full-script.js
+++ b/static/examples/full-script.js
@@ -1,25 +1,25 @@
-import { check, sleep } from "k6";
-import jsonpath from "https://jslib.k6.io/jsonpath/1.0.2/index.js"
-import { randomIntBetween, randomItem, uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
+import { check, sleep } from 'k6'
+import jsonpath from 'https://jslib.k6.io/jsonpath/1.0.2/index.js'
+import { randomIntBetween, randomItem, uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js'
 
 export const options = {
-  "duration": "10s",
-  "vus": 1
-};
+  duration: '10s',
+  vus: 1,
+}
 
 const testData = {
   user: {
-    name: "Batman"
-  }
-};
+    name: 'Batman',
+  },
+}
 
-export default function() {
+export default function () {
   check(testData, {
-    "JSON path works": () => jsonpath.value(testData, 'user.name') === "Batman"
-  });
+    'JSON path works': () => jsonpath.value(testData, 'user.name') === 'Batman',
+  })
 
-  console.log(uuidv4());
-  console.log(randomItem([1,2,3,4]));
+  console.log(uuidv4())
+  console.log(randomItem([1, 2, 3, 4]))
 
-  sleep(randomIntBetween(1,5)); // sleep between 1 and 5 seconds
+  sleep(randomIntBetween(1, 5)) // sleep between 1 and 5 seconds
 }

--- a/static/examples/imports.js
+++ b/static/examples/imports.js
@@ -1,5 +1,5 @@
 // Default import
-import jsonpath from "https://jslib.k6.io/jsonpath/1.0.2/index.js";
+import jsonpath from 'https://jslib.k6.io/jsonpath/1.0.2/index.js'
 
 // Non default import
-import { nonDefaultExport } from "https://jslib.k6.io/some-js-pkg/1.0.0/index.js";
+import { nonDefaultExport } from 'https://jslib.k6.io/some-js-pkg/1.0.0/index.js'

--- a/static/index-template.js
+++ b/static/index-template.js
@@ -1,35 +1,35 @@
 #!/usr/bin/env node
-const fs = require('fs');
-const createFont = require('../scripts/create-base64-font');
+const fs = require('fs')
+const createFont = require('../scripts/create-base64-font')
 
-const bootstrap = fs.readFileSync('./static/bootstrap.css', 'utf-8');
-const styles = fs.readFileSync('./static/styles.css', 'utf-8');
-const prisms = fs.readFileSync('./static/prisms.js', 'utf-8');
-const header = fs.readFileSync('./static/header.html', 'utf-8');
-const jumbo = fs.readFileSync('./static/jumbo.html', 'utf-8');
+const bootstrap = fs.readFileSync('./static/bootstrap.css', 'utf-8')
+const styles = fs.readFileSync('./static/styles.css', 'utf-8')
+const prisms = fs.readFileSync('./static/prisms.js', 'utf-8')
+const header = fs.readFileSync('./static/header.html', 'utf-8')
+const jumbo = fs.readFileSync('./static/jumbo.html', 'utf-8')
 
-const DOMAIN = 'https://jslib.k6.io';
+const DOMAIN = 'https://jslib.k6.io'
 
 const createLink = (name, version, main) => {
-  return `<a target="_blank" href="${DOMAIN}/${name}/${version}/${main}">${version}</a>`;
-};
+  return `<a target="_blank" href="${DOMAIN}/${name}/${version}/${main}">${version}</a>`
+}
 
 const versionsTable = () => {
-  const supported = require('../supported.json');
+  const supported = require('../supported.json')
   const trs = Object.entries(supported)
     .map(([name, lib]) => {
-      const bundleFilename = lib['bundle-filename'] ?? 'index.js';
+      const bundleFilename = lib['bundle-filename'] ?? 'index.js'
       const versionLinks = lib.versions
-        .map(version => createLink(name, version, bundleFilename))
-        .join(', ');
-        docsLink = lib['docs-url'] ? `<a href="${lib['docs-url']}">${lib['docs-url']}</a>`: "";
+        .map((version) => createLink(name, version, bundleFilename))
+        .join(', ')
+      docsLink = lib['docs-url'] ? `<a href="${lib['docs-url']}">${lib['docs-url']}</a>` : ''
       return `<tr>
       <td>${name}</td>
       <td>${versionLinks}</td>
       <td>${docsLink}</td>
-    </tr>`;
+    </tr>`
     })
-    .join('');
+    .join('')
 
   return `
     <table class="table">
@@ -42,13 +42,13 @@ const versionsTable = () => {
       </thead>
       ${trs}
     </table>
-  `;
-};
+  `
+}
 
-const codeExample = name => {
-  const snippet = fs.readFileSync(`./static/examples/${name}`, 'utf-8');
-  return `<pre><code class="code language-js">${snippet}</code></pre>`;
-};
+const codeExample = (name) => {
+  const snippet = fs.readFileSync(`./static/examples/${name}`, 'utf-8')
+  return `<pre><code class="code language-js">${snippet}</code></pre>`
+}
 
 function renderToString() {
   return `
@@ -129,7 +129,7 @@ function renderToString() {
       </script>
     </body>
     </html>
-  `;
+  `
 }
 
-module.exports = { renderToString };
+module.exports = { renderToString }

--- a/static/prisms.js
+++ b/static/prisms.js
@@ -1,7 +1,602 @@
 /* PrismJS 1.22.0
 https://prismjs.com/download.html#themes=prism&languages=clike+javascript&plugins=toolbar+copy-to-clipboard */
-var _self="undefined"!=typeof window?window:"undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?self:{},Prism=function(u){var c=/\blang(?:uage)?-([\w-]+)\b/i,n=0,_={manual:u.Prism&&u.Prism.manual,disableWorkerMessageHandler:u.Prism&&u.Prism.disableWorkerMessageHandler,util:{encode:function e(n){return n instanceof M?new M(n.type,e(n.content),n.alias):Array.isArray(n)?n.map(e):n.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/\u00a0/g," ")},type:function(e){return Object.prototype.toString.call(e).slice(8,-1)},objId:function(e){return e.__id||Object.defineProperty(e,"__id",{value:++n}),e.__id},clone:function t(e,r){var a,n;switch(r=r||{},_.util.type(e)){case"Object":if(n=_.util.objId(e),r[n])return r[n];for(var i in a={},r[n]=a,e)e.hasOwnProperty(i)&&(a[i]=t(e[i],r));return a;case"Array":return n=_.util.objId(e),r[n]?r[n]:(a=[],r[n]=a,e.forEach(function(e,n){a[n]=t(e,r)}),a);default:return e}},getLanguage:function(e){for(;e&&!c.test(e.className);)e=e.parentElement;return e?(e.className.match(c)||[,"none"])[1].toLowerCase():"none"},currentScript:function(){if("undefined"==typeof document)return null;if("currentScript"in document)return document.currentScript;try{throw new Error}catch(e){var n=(/at [^(\r\n]*\((.*):.+:.+\)$/i.exec(e.stack)||[])[1];if(n){var t=document.getElementsByTagName("script");for(var r in t)if(t[r].src==n)return t[r]}return null}},isActive:function(e,n,t){for(var r="no-"+n;e;){var a=e.classList;if(a.contains(n))return!0;if(a.contains(r))return!1;e=e.parentElement}return!!t}},languages:{extend:function(e,n){var t=_.util.clone(_.languages[e]);for(var r in n)t[r]=n[r];return t},insertBefore:function(t,e,n,r){var a=(r=r||_.languages)[t],i={};for(var l in a)if(a.hasOwnProperty(l)){if(l==e)for(var o in n)n.hasOwnProperty(o)&&(i[o]=n[o]);n.hasOwnProperty(l)||(i[l]=a[l])}var s=r[t];return r[t]=i,_.languages.DFS(_.languages,function(e,n){n===s&&e!=t&&(this[e]=i)}),i},DFS:function e(n,t,r,a){a=a||{};var i=_.util.objId;for(var l in n)if(n.hasOwnProperty(l)){t.call(n,l,n[l],r||l);var o=n[l],s=_.util.type(o);"Object"!==s||a[i(o)]?"Array"!==s||a[i(o)]||(a[i(o)]=!0,e(o,t,l,a)):(a[i(o)]=!0,e(o,t,null,a))}}},plugins:{},highlightAll:function(e,n){_.highlightAllUnder(document,e,n)},highlightAllUnder:function(e,n,t){var r={callback:t,container:e,selector:'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code'};_.hooks.run("before-highlightall",r),r.elements=Array.prototype.slice.apply(r.container.querySelectorAll(r.selector)),_.hooks.run("before-all-elements-highlight",r);for(var a,i=0;a=r.elements[i++];)_.highlightElement(a,!0===n,r.callback)},highlightElement:function(e,n,t){var r=_.util.getLanguage(e),a=_.languages[r];e.className=e.className.replace(c,"").replace(/\s+/g," ")+" language-"+r;var i=e.parentElement;i&&"pre"===i.nodeName.toLowerCase()&&(i.className=i.className.replace(c,"").replace(/\s+/g," ")+" language-"+r);var l={element:e,language:r,grammar:a,code:e.textContent};function o(e){l.highlightedCode=e,_.hooks.run("before-insert",l),l.element.innerHTML=l.highlightedCode,_.hooks.run("after-highlight",l),_.hooks.run("complete",l),t&&t.call(l.element)}if(_.hooks.run("before-sanity-check",l),!l.code)return _.hooks.run("complete",l),void(t&&t.call(l.element));if(_.hooks.run("before-highlight",l),l.grammar)if(n&&u.Worker){var s=new Worker(_.filename);s.onmessage=function(e){o(e.data)},s.postMessage(JSON.stringify({language:l.language,code:l.code,immediateClose:!0}))}else o(_.highlight(l.code,l.grammar,l.language));else o(_.util.encode(l.code))},highlight:function(e,n,t){var r={code:e,grammar:n,language:t};return _.hooks.run("before-tokenize",r),r.tokens=_.tokenize(r.code,r.grammar),_.hooks.run("after-tokenize",r),M.stringify(_.util.encode(r.tokens),r.language)},tokenize:function(e,n){var t=n.rest;if(t){for(var r in t)n[r]=t[r];delete n.rest}var a=new i;return z(a,a.head,e),function e(n,t,r,a,i,l){for(var o in r)if(r.hasOwnProperty(o)&&r[o]){var s=r[o];s=Array.isArray(s)?s:[s];for(var u=0;u<s.length;++u){if(l&&l.cause==o+","+u)return;var c=s[u],g=c.inside,f=!!c.lookbehind,h=!!c.greedy,d=c.alias;if(h&&!c.pattern.global){var v=c.pattern.toString().match(/[imsuy]*$/)[0];c.pattern=RegExp(c.pattern.source,v+"g")}for(var p=c.pattern||c,m=a.next,y=i;m!==t.tail&&!(l&&y>=l.reach);y+=m.value.length,m=m.next){var k=m.value;if(t.length>n.length)return;if(!(k instanceof M)){var b,x=1;if(h){if(!(b=W(p,y,n,f)))break;var w=b.index,A=b.index+b[0].length,P=y;for(P+=m.value.length;P<=w;)m=m.next,P+=m.value.length;if(P-=m.value.length,y=P,m.value instanceof M)continue;for(var S=m;S!==t.tail&&(P<A||"string"==typeof S.value);S=S.next)x++,P+=S.value.length;x--,k=n.slice(y,P),b.index-=y}else if(!(b=W(p,0,k,f)))continue;var w=b.index,E=b[0],O=k.slice(0,w),L=k.slice(w+E.length),N=y+k.length;l&&N>l.reach&&(l.reach=N);var j=m.prev;O&&(j=z(t,j,O),y+=O.length),I(t,j,x);var C=new M(o,g?_.tokenize(E,g):E,d,E);m=z(t,j,C),L&&z(t,m,L),1<x&&e(n,t,r,m.prev,y,{cause:o+","+u,reach:N})}}}}}(e,a,n,a.head,0),function(e){var n=[],t=e.head.next;for(;t!==e.tail;)n.push(t.value),t=t.next;return n}(a)},hooks:{all:{},add:function(e,n){var t=_.hooks.all;t[e]=t[e]||[],t[e].push(n)},run:function(e,n){var t=_.hooks.all[e];if(t&&t.length)for(var r,a=0;r=t[a++];)r(n)}},Token:M};function M(e,n,t,r){this.type=e,this.content=n,this.alias=t,this.length=0|(r||"").length}function W(e,n,t,r){e.lastIndex=n;var a=e.exec(t);if(a&&r&&a[1]){var i=a[1].length;a.index+=i,a[0]=a[0].slice(i)}return a}function i(){var e={value:null,prev:null,next:null},n={value:null,prev:e,next:null};e.next=n,this.head=e,this.tail=n,this.length=0}function z(e,n,t){var r=n.next,a={value:t,prev:n,next:r};return n.next=a,r.prev=a,e.length++,a}function I(e,n,t){for(var r=n.next,a=0;a<t&&r!==e.tail;a++)r=r.next;(n.next=r).prev=n,e.length-=a}if(u.Prism=_,M.stringify=function n(e,t){if("string"==typeof e)return e;if(Array.isArray(e)){var r="";return e.forEach(function(e){r+=n(e,t)}),r}var a={type:e.type,content:n(e.content,t),tag:"span",classes:["token",e.type],attributes:{},language:t},i=e.alias;i&&(Array.isArray(i)?Array.prototype.push.apply(a.classes,i):a.classes.push(i)),_.hooks.run("wrap",a);var l="";for(var o in a.attributes)l+=" "+o+'="'+(a.attributes[o]||"").replace(/"/g,"&quot;")+'"';return"<"+a.tag+' class="'+a.classes.join(" ")+'"'+l+">"+a.content+"</"+a.tag+">"},!u.document)return u.addEventListener&&(_.disableWorkerMessageHandler||u.addEventListener("message",function(e){var n=JSON.parse(e.data),t=n.language,r=n.code,a=n.immediateClose;u.postMessage(_.highlight(r,_.languages[t],t)),a&&u.close()},!1)),_;var e=_.util.currentScript();function t(){_.manual||_.highlightAll()}if(e&&(_.filename=e.src,e.hasAttribute("data-manual")&&(_.manual=!0)),!_.manual){var r=document.readyState;"loading"===r||"interactive"===r&&e&&e.defer?document.addEventListener("DOMContentLoaded",t):window.requestAnimationFrame?window.requestAnimationFrame(t):window.setTimeout(t,16)}return _}(_self);"undefined"!=typeof module&&module.exports&&(module.exports=Prism),"undefined"!=typeof global&&(global.Prism=Prism);
-Prism.languages.clike={comment:[{pattern:/(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,lookbehind:!0},{pattern:/(^|[^\\:])\/\/.*/,lookbehind:!0,greedy:!0}],string:{pattern:/(["'])(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,greedy:!0},"class-name":{pattern:/(\b(?:class|interface|extends|implements|trait|instanceof|new)\s+|\bcatch\s+\()[\w.\\]+/i,lookbehind:!0,inside:{punctuation:/[.\\]/}},keyword:/\b(?:if|else|while|do|for|return|in|instanceof|function|new|try|throw|catch|finally|null|break|continue)\b/,boolean:/\b(?:true|false)\b/,function:/\w+(?=\()/,number:/\b0x[\da-f]+\b|(?:\b\d+\.?\d*|\B\.\d+)(?:e[+-]?\d+)?/i,operator:/[<>]=?|[!=]=?=?|--?|\+\+?|&&?|\|\|?|[?*/~^%]/,punctuation:/[{}[\];(),.:]/};
-Prism.languages.javascript=Prism.languages.extend("clike",{"class-name":[Prism.languages.clike["class-name"],{pattern:/(^|[^$\w\xA0-\uFFFF])[_$A-Z\xA0-\uFFFF][$\w\xA0-\uFFFF]*(?=\.(?:prototype|constructor))/,lookbehind:!0}],keyword:[{pattern:/((?:^|})\s*)(?:catch|finally)\b/,lookbehind:!0},{pattern:/(^|[^.]|\.\.\.\s*)\b(?:as|async(?=\s*(?:function\b|\(|[$\w\xA0-\uFFFF]|$))|await|break|case|class|const|continue|debugger|default|delete|do|else|enum|export|extends|for|from|function|(?:get|set)(?=\s*[\[$\w\xA0-\uFFFF])|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|static|super|switch|this|throw|try|typeof|undefined|var|void|while|with|yield)\b/,lookbehind:!0}],number:/\b(?:(?:0[xX](?:[\dA-Fa-f](?:_[\dA-Fa-f])?)+|0[bB](?:[01](?:_[01])?)+|0[oO](?:[0-7](?:_[0-7])?)+)n?|(?:\d(?:_\d)?)+n|NaN|Infinity)\b|(?:\b(?:\d(?:_\d)?)+\.?(?:\d(?:_\d)?)*|\B\.(?:\d(?:_\d)?)+)(?:[Ee][+-]?(?:\d(?:_\d)?)+)?/,function:/#?[_$a-zA-Z\xA0-\uFFFF][$\w\xA0-\uFFFF]*(?=\s*(?:\.\s*(?:apply|bind|call)\s*)?\()/,operator:/--|\+\+|\*\*=?|=>|&&=?|\|\|=?|[!=]==|<<=?|>>>?=?|[-+*/%&|^!=<>]=?|\.{3}|\?\?=?|\?\.?|[~:]/}),Prism.languages.javascript["class-name"][0].pattern=/(\b(?:class|interface|extends|implements|instanceof|new)\s+)[\w.\\]+/,Prism.languages.insertBefore("javascript","keyword",{regex:{pattern:/((?:^|[^$\w\xA0-\uFFFF."'\])\s]|\b(?:return|yield))\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*]|\\.|[^/\\\[\r\n])+\/[gimyus]{0,6}(?=(?:\s|\/\*(?:[^*]|\*(?!\/))*\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,lookbehind:!0,greedy:!0,inside:{"regex-source":{pattern:/^(\/)[\s\S]+(?=\/[a-z]*$)/,lookbehind:!0,alias:"language-regex",inside:Prism.languages.regex},"regex-flags":/[a-z]+$/,"regex-delimiter":/^\/|\/$/}},"function-variable":{pattern:/#?[_$a-zA-Z\xA0-\uFFFF][$\w\xA0-\uFFFF]*(?=\s*[=:]\s*(?:async\s*)?(?:\bfunction\b|(?:\((?:[^()]|\([^()]*\))*\)|[_$a-zA-Z\xA0-\uFFFF][$\w\xA0-\uFFFF]*)\s*=>))/,alias:"function"},parameter:[{pattern:/(function(?:\s+[_$A-Za-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*)?\s*\(\s*)(?!\s)(?:[^()]|\([^()]*\))+?(?=\s*\))/,lookbehind:!0,inside:Prism.languages.javascript},{pattern:/[_$a-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*(?=\s*=>)/i,inside:Prism.languages.javascript},{pattern:/(\(\s*)(?!\s)(?:[^()]|\([^()]*\))+?(?=\s*\)\s*=>)/,lookbehind:!0,inside:Prism.languages.javascript},{pattern:/((?:\b|\s|^)(?!(?:as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|undefined|var|void|while|with|yield)(?![$\w\xA0-\uFFFF]))(?:[_$A-Za-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*\s*)\(\s*|\]\s*\(\s*)(?!\s)(?:[^()]|\([^()]*\))+?(?=\s*\)\s*\{)/,lookbehind:!0,inside:Prism.languages.javascript}],constant:/\b[A-Z](?:[A-Z_]|\dx?)*\b/}),Prism.languages.insertBefore("javascript","string",{"template-string":{pattern:/`(?:\\[\s\S]|\${(?:[^{}]|{(?:[^{}]|{[^}]*})*})+}|(?!\${)[^\\`])*`/,greedy:!0,inside:{"template-punctuation":{pattern:/^`|`$/,alias:"string"},interpolation:{pattern:/((?:^|[^\\])(?:\\{2})*)\${(?:[^{}]|{(?:[^{}]|{[^}]*})*})+}/,lookbehind:!0,inside:{"interpolation-punctuation":{pattern:/^\${|}$/,alias:"punctuation"},rest:Prism.languages.javascript}},string:/[\s\S]+/}}}),Prism.languages.markup&&Prism.languages.markup.tag.addInlined("script","javascript"),Prism.languages.js=Prism.languages.javascript;
-!function(){if("undefined"!=typeof self&&self.Prism&&self.document){var i=[],l={},c=function(){};Prism.plugins.toolbar={};var e=Prism.plugins.toolbar.registerButton=function(e,n){var t;t="function"==typeof n?n:function(e){var t;return"function"==typeof n.onClick?((t=document.createElement("button")).type="button",t.addEventListener("click",function(){n.onClick.call(this,e)})):"string"==typeof n.url?(t=document.createElement("a")).href=n.url:t=document.createElement("span"),n.className&&t.classList.add(n.className),t.textContent=n.text,t},e in l?console.warn('There is a button with the key "'+e+'" registered already.'):i.push(l[e]=t)},t=Prism.plugins.toolbar.hook=function(a){var e=a.element.parentNode;if(e&&/pre/i.test(e.nodeName)&&!e.parentNode.classList.contains("code-toolbar")){var t=document.createElement("div");t.classList.add("code-toolbar"),e.parentNode.insertBefore(t,e),t.appendChild(e);var r=document.createElement("div");r.classList.add("toolbar");var n=i,o=function(e){for(;e;){var t=e.getAttribute("data-toolbar-order");if(null!=t)return(t=t.trim()).length?t.split(/\s*,\s*/g):[];e=e.parentElement}}(a.element);o&&(n=o.map(function(e){return l[e]||c})),n.forEach(function(e){var t=e(a);if(t){var n=document.createElement("div");n.classList.add("toolbar-item"),n.appendChild(t),r.appendChild(n)}}),t.appendChild(r)}};e("label",function(e){var t=e.element.parentNode;if(t&&/pre/i.test(t.nodeName)&&t.hasAttribute("data-label")){var n,a,r=t.getAttribute("data-label");try{a=document.querySelector("template#"+r)}catch(e){}return a?n=a.content:(t.hasAttribute("data-url")?(n=document.createElement("a")).href=t.getAttribute("data-url"):n=document.createElement("span"),n.textContent=r),n}}),Prism.hooks.add("complete",t)}}();
-!function(){if("undefined"!=typeof self&&self.Prism&&self.document)if(Prism.plugins.toolbar){var i=window.ClipboardJS||void 0;i||"function"!=typeof require||(i=require("clipboard"));var u=[];if(!i){var t=document.createElement("script"),e=document.querySelector("head");t.onload=function(){if(i=window.ClipboardJS)for(;u.length;)u.pop()()},t.src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js",e.appendChild(t)}Prism.plugins.toolbar.registerButton("copy-to-clipboard",function(t){var e=document.createElement("button");e.textContent="Copy",e.setAttribute("type","button");var o=t.element;return i?n():u.push(n),e;function n(){var t=new i(e,{text:function(){return o.textContent}});t.on("success",function(){e.textContent="Copied!",r()}),t.on("error",function(){e.textContent="Press Ctrl+C to copy",r()})}function r(){setTimeout(function(){e.textContent="Copy"},5e3)}})}else console.warn("Copy to Clipboard plugin loaded before Toolbar plugin.")}();
+var _self =
+    'undefined' != typeof window
+      ? window
+      : 'undefined' != typeof WorkerGlobalScope && self instanceof WorkerGlobalScope
+      ? self
+      : {},
+  Prism = (function (u) {
+    var c = /\blang(?:uage)?-([\w-]+)\b/i,
+      n = 0,
+      _ = {
+        manual: u.Prism && u.Prism.manual,
+        disableWorkerMessageHandler: u.Prism && u.Prism.disableWorkerMessageHandler,
+        util: {
+          encode: function e(n) {
+            return n instanceof M
+              ? new M(n.type, e(n.content), n.alias)
+              : Array.isArray(n)
+              ? n.map(e)
+              : n
+                  .replace(/&/g, '&amp;')
+                  .replace(/</g, '&lt;')
+                  .replace(/\u00a0/g, ' ')
+          },
+          type: function (e) {
+            return Object.prototype.toString.call(e).slice(8, -1)
+          },
+          objId: function (e) {
+            return e.__id || Object.defineProperty(e, '__id', { value: ++n }), e.__id
+          },
+          clone: function t(e, r) {
+            var a, n
+            switch (((r = r || {}), _.util.type(e))) {
+              case 'Object':
+                if (((n = _.util.objId(e)), r[n])) return r[n]
+                for (var i in ((a = {}), (r[n] = a), e)) e.hasOwnProperty(i) && (a[i] = t(e[i], r))
+                return a
+              case 'Array':
+                return (
+                  (n = _.util.objId(e)),
+                  r[n]
+                    ? r[n]
+                    : ((a = []),
+                      (r[n] = a),
+                      e.forEach(function (e, n) {
+                        a[n] = t(e, r)
+                      }),
+                      a)
+                )
+              default:
+                return e
+            }
+          },
+          getLanguage: function (e) {
+            for (; e && !c.test(e.className); ) e = e.parentElement
+            return e ? (e.className.match(c) || [, 'none'])[1].toLowerCase() : 'none'
+          },
+          currentScript: function () {
+            if ('undefined' == typeof document) return null
+            if ('currentScript' in document) return document.currentScript
+            try {
+              throw new Error()
+            } catch (e) {
+              var n = (/at [^(\r\n]*\((.*):.+:.+\)$/i.exec(e.stack) || [])[1]
+              if (n) {
+                var t = document.getElementsByTagName('script')
+                for (var r in t) if (t[r].src == n) return t[r]
+              }
+              return null
+            }
+          },
+          isActive: function (e, n, t) {
+            for (var r = 'no-' + n; e; ) {
+              var a = e.classList
+              if (a.contains(n)) return !0
+              if (a.contains(r)) return !1
+              e = e.parentElement
+            }
+            return !!t
+          },
+        },
+        languages: {
+          extend: function (e, n) {
+            var t = _.util.clone(_.languages[e])
+            for (var r in n) t[r] = n[r]
+            return t
+          },
+          insertBefore: function (t, e, n, r) {
+            var a = (r = r || _.languages)[t],
+              i = {}
+            for (var l in a)
+              if (a.hasOwnProperty(l)) {
+                if (l == e) for (var o in n) n.hasOwnProperty(o) && (i[o] = n[o])
+                n.hasOwnProperty(l) || (i[l] = a[l])
+              }
+            var s = r[t]
+            return (
+              (r[t] = i),
+              _.languages.DFS(_.languages, function (e, n) {
+                n === s && e != t && (this[e] = i)
+              }),
+              i
+            )
+          },
+          DFS: function e(n, t, r, a) {
+            a = a || {}
+            var i = _.util.objId
+            for (var l in n)
+              if (n.hasOwnProperty(l)) {
+                t.call(n, l, n[l], r || l)
+                var o = n[l],
+                  s = _.util.type(o)
+                'Object' !== s || a[i(o)]
+                  ? 'Array' !== s || a[i(o)] || ((a[i(o)] = !0), e(o, t, l, a))
+                  : ((a[i(o)] = !0), e(o, t, null, a))
+              }
+          },
+        },
+        plugins: {},
+        highlightAll: function (e, n) {
+          _.highlightAllUnder(document, e, n)
+        },
+        highlightAllUnder: function (e, n, t) {
+          var r = {
+            callback: t,
+            container: e,
+            selector:
+              'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code',
+          }
+          _.hooks.run('before-highlightall', r),
+            (r.elements = Array.prototype.slice.apply(r.container.querySelectorAll(r.selector))),
+            _.hooks.run('before-all-elements-highlight', r)
+          for (var a, i = 0; (a = r.elements[i++]); ) _.highlightElement(a, !0 === n, r.callback)
+        },
+        highlightElement: function (e, n, t) {
+          var r = _.util.getLanguage(e),
+            a = _.languages[r]
+          e.className = e.className.replace(c, '').replace(/\s+/g, ' ') + ' language-' + r
+          var i = e.parentElement
+          i &&
+            'pre' === i.nodeName.toLowerCase() &&
+            (i.className = i.className.replace(c, '').replace(/\s+/g, ' ') + ' language-' + r)
+          var l = { element: e, language: r, grammar: a, code: e.textContent }
+          function o(e) {
+            ;(l.highlightedCode = e),
+              _.hooks.run('before-insert', l),
+              (l.element.innerHTML = l.highlightedCode),
+              _.hooks.run('after-highlight', l),
+              _.hooks.run('complete', l),
+              t && t.call(l.element)
+          }
+          if ((_.hooks.run('before-sanity-check', l), !l.code))
+            return _.hooks.run('complete', l), void (t && t.call(l.element))
+          if ((_.hooks.run('before-highlight', l), l.grammar))
+            if (n && u.Worker) {
+              var s = new Worker(_.filename)
+              ;(s.onmessage = function (e) {
+                o(e.data)
+              }),
+                s.postMessage(
+                  JSON.stringify({ language: l.language, code: l.code, immediateClose: !0 })
+                )
+            } else o(_.highlight(l.code, l.grammar, l.language))
+          else o(_.util.encode(l.code))
+        },
+        highlight: function (e, n, t) {
+          var r = { code: e, grammar: n, language: t }
+          return (
+            _.hooks.run('before-tokenize', r),
+            (r.tokens = _.tokenize(r.code, r.grammar)),
+            _.hooks.run('after-tokenize', r),
+            M.stringify(_.util.encode(r.tokens), r.language)
+          )
+        },
+        tokenize: function (e, n) {
+          var t = n.rest
+          if (t) {
+            for (var r in t) n[r] = t[r]
+            delete n.rest
+          }
+          var a = new i()
+          return (
+            z(a, a.head, e),
+            (function e(n, t, r, a, i, l) {
+              for (var o in r)
+                if (r.hasOwnProperty(o) && r[o]) {
+                  var s = r[o]
+                  s = Array.isArray(s) ? s : [s]
+                  for (var u = 0; u < s.length; ++u) {
+                    if (l && l.cause == o + ',' + u) return
+                    var c = s[u],
+                      g = c.inside,
+                      f = !!c.lookbehind,
+                      h = !!c.greedy,
+                      d = c.alias
+                    if (h && !c.pattern.global) {
+                      var v = c.pattern.toString().match(/[imsuy]*$/)[0]
+                      c.pattern = RegExp(c.pattern.source, v + 'g')
+                    }
+                    for (
+                      var p = c.pattern || c, m = a.next, y = i;
+                      m !== t.tail && !(l && y >= l.reach);
+                      y += m.value.length, m = m.next
+                    ) {
+                      var k = m.value
+                      if (t.length > n.length) return
+                      if (!(k instanceof M)) {
+                        var b,
+                          x = 1
+                        if (h) {
+                          if (!(b = W(p, y, n, f))) break
+                          var w = b.index,
+                            A = b.index + b[0].length,
+                            P = y
+                          for (P += m.value.length; P <= w; ) (m = m.next), (P += m.value.length)
+                          if (((P -= m.value.length), (y = P), m.value instanceof M)) continue
+                          for (
+                            var S = m;
+                            S !== t.tail && (P < A || 'string' == typeof S.value);
+                            S = S.next
+                          )
+                            x++, (P += S.value.length)
+                          x--, (k = n.slice(y, P)), (b.index -= y)
+                        } else if (!(b = W(p, 0, k, f))) continue
+                        var w = b.index,
+                          E = b[0],
+                          O = k.slice(0, w),
+                          L = k.slice(w + E.length),
+                          N = y + k.length
+                        l && N > l.reach && (l.reach = N)
+                        var j = m.prev
+                        O && ((j = z(t, j, O)), (y += O.length)), I(t, j, x)
+                        var C = new M(o, g ? _.tokenize(E, g) : E, d, E)
+                        ;(m = z(t, j, C)),
+                          L && z(t, m, L),
+                          1 < x && e(n, t, r, m.prev, y, { cause: o + ',' + u, reach: N })
+                      }
+                    }
+                  }
+                }
+            })(e, a, n, a.head, 0),
+            (function (e) {
+              var n = [],
+                t = e.head.next
+              for (; t !== e.tail; ) n.push(t.value), (t = t.next)
+              return n
+            })(a)
+          )
+        },
+        hooks: {
+          all: {},
+          add: function (e, n) {
+            var t = _.hooks.all
+            ;(t[e] = t[e] || []), t[e].push(n)
+          },
+          run: function (e, n) {
+            var t = _.hooks.all[e]
+            if (t && t.length) for (var r, a = 0; (r = t[a++]); ) r(n)
+          },
+        },
+        Token: M,
+      }
+    function M(e, n, t, r) {
+      ;(this.type = e), (this.content = n), (this.alias = t), (this.length = 0 | (r || '').length)
+    }
+    function W(e, n, t, r) {
+      e.lastIndex = n
+      var a = e.exec(t)
+      if (a && r && a[1]) {
+        var i = a[1].length
+        ;(a.index += i), (a[0] = a[0].slice(i))
+      }
+      return a
+    }
+    function i() {
+      var e = { value: null, prev: null, next: null },
+        n = { value: null, prev: e, next: null }
+      ;(e.next = n), (this.head = e), (this.tail = n), (this.length = 0)
+    }
+    function z(e, n, t) {
+      var r = n.next,
+        a = { value: t, prev: n, next: r }
+      return (n.next = a), (r.prev = a), e.length++, a
+    }
+    function I(e, n, t) {
+      for (var r = n.next, a = 0; a < t && r !== e.tail; a++) r = r.next
+      ;((n.next = r).prev = n), (e.length -= a)
+    }
+    if (
+      ((u.Prism = _),
+      (M.stringify = function n(e, t) {
+        if ('string' == typeof e) return e
+        if (Array.isArray(e)) {
+          var r = ''
+          return (
+            e.forEach(function (e) {
+              r += n(e, t)
+            }),
+            r
+          )
+        }
+        var a = {
+            type: e.type,
+            content: n(e.content, t),
+            tag: 'span',
+            classes: ['token', e.type],
+            attributes: {},
+            language: t,
+          },
+          i = e.alias
+        i && (Array.isArray(i) ? Array.prototype.push.apply(a.classes, i) : a.classes.push(i)),
+          _.hooks.run('wrap', a)
+        var l = ''
+        for (var o in a.attributes)
+          l += ' ' + o + '="' + (a.attributes[o] || '').replace(/"/g, '&quot;') + '"'
+        return (
+          '<' +
+          a.tag +
+          ' class="' +
+          a.classes.join(' ') +
+          '"' +
+          l +
+          '>' +
+          a.content +
+          '</' +
+          a.tag +
+          '>'
+        )
+      }),
+      !u.document)
+    )
+      return (
+        u.addEventListener &&
+          (_.disableWorkerMessageHandler ||
+            u.addEventListener(
+              'message',
+              function (e) {
+                var n = JSON.parse(e.data),
+                  t = n.language,
+                  r = n.code,
+                  a = n.immediateClose
+                u.postMessage(_.highlight(r, _.languages[t], t)), a && u.close()
+              },
+              !1
+            )),
+        _
+      )
+    var e = _.util.currentScript()
+    function t() {
+      _.manual || _.highlightAll()
+    }
+    if (
+      (e && ((_.filename = e.src), e.hasAttribute('data-manual') && (_.manual = !0)), !_.manual)
+    ) {
+      var r = document.readyState
+      'loading' === r || ('interactive' === r && e && e.defer)
+        ? document.addEventListener('DOMContentLoaded', t)
+        : window.requestAnimationFrame
+        ? window.requestAnimationFrame(t)
+        : window.setTimeout(t, 16)
+    }
+    return _
+  })(_self)
+'undefined' != typeof module && module.exports && (module.exports = Prism),
+  'undefined' != typeof global && (global.Prism = Prism)
+Prism.languages.clike = {
+  comment: [
+    { pattern: /(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/, lookbehind: !0 },
+    { pattern: /(^|[^\\:])\/\/.*/, lookbehind: !0, greedy: !0 },
+  ],
+  string: { pattern: /(["'])(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/, greedy: !0 },
+  'class-name': {
+    pattern:
+      /(\b(?:class|interface|extends|implements|trait|instanceof|new)\s+|\bcatch\s+\()[\w.\\]+/i,
+    lookbehind: !0,
+    inside: { punctuation: /[.\\]/ },
+  },
+  keyword:
+    /\b(?:if|else|while|do|for|return|in|instanceof|function|new|try|throw|catch|finally|null|break|continue)\b/,
+  boolean: /\b(?:true|false)\b/,
+  function: /\w+(?=\()/,
+  number: /\b0x[\da-f]+\b|(?:\b\d+\.?\d*|\B\.\d+)(?:e[+-]?\d+)?/i,
+  operator: /[<>]=?|[!=]=?=?|--?|\+\+?|&&?|\|\|?|[?*/~^%]/,
+  punctuation: /[{}[\];(),.:]/,
+}
+;(Prism.languages.javascript = Prism.languages.extend('clike', {
+  'class-name': [
+    Prism.languages.clike['class-name'],
+    {
+      pattern:
+        /(^|[^$\w\xA0-\uFFFF])[_$A-Z\xA0-\uFFFF][$\w\xA0-\uFFFF]*(?=\.(?:prototype|constructor))/,
+      lookbehind: !0,
+    },
+  ],
+  keyword: [
+    { pattern: /((?:^|})\s*)(?:catch|finally)\b/, lookbehind: !0 },
+    {
+      pattern:
+        /(^|[^.]|\.\.\.\s*)\b(?:as|async(?=\s*(?:function\b|\(|[$\w\xA0-\uFFFF]|$))|await|break|case|class|const|continue|debugger|default|delete|do|else|enum|export|extends|for|from|function|(?:get|set)(?=\s*[\[$\w\xA0-\uFFFF])|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|static|super|switch|this|throw|try|typeof|undefined|var|void|while|with|yield)\b/,
+      lookbehind: !0,
+    },
+  ],
+  number:
+    /\b(?:(?:0[xX](?:[\dA-Fa-f](?:_[\dA-Fa-f])?)+|0[bB](?:[01](?:_[01])?)+|0[oO](?:[0-7](?:_[0-7])?)+)n?|(?:\d(?:_\d)?)+n|NaN|Infinity)\b|(?:\b(?:\d(?:_\d)?)+\.?(?:\d(?:_\d)?)*|\B\.(?:\d(?:_\d)?)+)(?:[Ee][+-]?(?:\d(?:_\d)?)+)?/,
+  function: /#?[_$a-zA-Z\xA0-\uFFFF][$\w\xA0-\uFFFF]*(?=\s*(?:\.\s*(?:apply|bind|call)\s*)?\()/,
+  operator:
+    /--|\+\+|\*\*=?|=>|&&=?|\|\|=?|[!=]==|<<=?|>>>?=?|[-+*/%&|^!=<>]=?|\.{3}|\?\?=?|\?\.?|[~:]/,
+})),
+  (Prism.languages.javascript['class-name'][0].pattern =
+    /(\b(?:class|interface|extends|implements|instanceof|new)\s+)[\w.\\]+/),
+  Prism.languages.insertBefore('javascript', 'keyword', {
+    regex: {
+      pattern:
+        /((?:^|[^$\w\xA0-\uFFFF."'\])\s]|\b(?:return|yield))\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*]|\\.|[^/\\\[\r\n])+\/[gimyus]{0,6}(?=(?:\s|\/\*(?:[^*]|\*(?!\/))*\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,
+      lookbehind: !0,
+      greedy: !0,
+      inside: {
+        'regex-source': {
+          pattern: /^(\/)[\s\S]+(?=\/[a-z]*$)/,
+          lookbehind: !0,
+          alias: 'language-regex',
+          inside: Prism.languages.regex,
+        },
+        'regex-flags': /[a-z]+$/,
+        'regex-delimiter': /^\/|\/$/,
+      },
+    },
+    'function-variable': {
+      pattern:
+        /#?[_$a-zA-Z\xA0-\uFFFF][$\w\xA0-\uFFFF]*(?=\s*[=:]\s*(?:async\s*)?(?:\bfunction\b|(?:\((?:[^()]|\([^()]*\))*\)|[_$a-zA-Z\xA0-\uFFFF][$\w\xA0-\uFFFF]*)\s*=>))/,
+      alias: 'function',
+    },
+    parameter: [
+      {
+        pattern:
+          /(function(?:\s+[_$A-Za-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*)?\s*\(\s*)(?!\s)(?:[^()]|\([^()]*\))+?(?=\s*\))/,
+        lookbehind: !0,
+        inside: Prism.languages.javascript,
+      },
+      {
+        pattern: /[_$a-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*(?=\s*=>)/i,
+        inside: Prism.languages.javascript,
+      },
+      {
+        pattern: /(\(\s*)(?!\s)(?:[^()]|\([^()]*\))+?(?=\s*\)\s*=>)/,
+        lookbehind: !0,
+        inside: Prism.languages.javascript,
+      },
+      {
+        pattern:
+          /((?:\b|\s|^)(?!(?:as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|undefined|var|void|while|with|yield)(?![$\w\xA0-\uFFFF]))(?:[_$A-Za-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*\s*)\(\s*|\]\s*\(\s*)(?!\s)(?:[^()]|\([^()]*\))+?(?=\s*\)\s*\{)/,
+        lookbehind: !0,
+        inside: Prism.languages.javascript,
+      },
+    ],
+    constant: /\b[A-Z](?:[A-Z_]|\dx?)*\b/,
+  }),
+  Prism.languages.insertBefore('javascript', 'string', {
+    'template-string': {
+      pattern: /`(?:\\[\s\S]|\${(?:[^{}]|{(?:[^{}]|{[^}]*})*})+}|(?!\${)[^\\`])*`/,
+      greedy: !0,
+      inside: {
+        'template-punctuation': { pattern: /^`|`$/, alias: 'string' },
+        interpolation: {
+          pattern: /((?:^|[^\\])(?:\\{2})*)\${(?:[^{}]|{(?:[^{}]|{[^}]*})*})+}/,
+          lookbehind: !0,
+          inside: {
+            'interpolation-punctuation': { pattern: /^\${|}$/, alias: 'punctuation' },
+            rest: Prism.languages.javascript,
+          },
+        },
+        string: /[\s\S]+/,
+      },
+    },
+  }),
+  Prism.languages.markup && Prism.languages.markup.tag.addInlined('script', 'javascript'),
+  (Prism.languages.js = Prism.languages.javascript)
+!(function () {
+  if ('undefined' != typeof self && self.Prism && self.document) {
+    var i = [],
+      l = {},
+      c = function () {}
+    Prism.plugins.toolbar = {}
+    var e = (Prism.plugins.toolbar.registerButton = function (e, n) {
+        var t
+        ;(t =
+          'function' == typeof n
+            ? n
+            : function (e) {
+                var t
+                return (
+                  'function' == typeof n.onClick
+                    ? (((t = document.createElement('button')).type = 'button'),
+                      t.addEventListener('click', function () {
+                        n.onClick.call(this, e)
+                      }))
+                    : 'string' == typeof n.url
+                    ? ((t = document.createElement('a')).href = n.url)
+                    : (t = document.createElement('span')),
+                  n.className && t.classList.add(n.className),
+                  (t.textContent = n.text),
+                  t
+                )
+              }),
+          e in l
+            ? console.warn('There is a button with the key "' + e + '" registered already.')
+            : i.push((l[e] = t))
+      }),
+      t = (Prism.plugins.toolbar.hook = function (a) {
+        var e = a.element.parentNode
+        if (e && /pre/i.test(e.nodeName) && !e.parentNode.classList.contains('code-toolbar')) {
+          var t = document.createElement('div')
+          t.classList.add('code-toolbar'), e.parentNode.insertBefore(t, e), t.appendChild(e)
+          var r = document.createElement('div')
+          r.classList.add('toolbar')
+          var n = i,
+            o = (function (e) {
+              for (; e; ) {
+                var t = e.getAttribute('data-toolbar-order')
+                if (null != t) return (t = t.trim()).length ? t.split(/\s*,\s*/g) : []
+                e = e.parentElement
+              }
+            })(a.element)
+          o &&
+            (n = o.map(function (e) {
+              return l[e] || c
+            })),
+            n.forEach(function (e) {
+              var t = e(a)
+              if (t) {
+                var n = document.createElement('div')
+                n.classList.add('toolbar-item'), n.appendChild(t), r.appendChild(n)
+              }
+            }),
+            t.appendChild(r)
+        }
+      })
+    e('label', function (e) {
+      var t = e.element.parentNode
+      if (t && /pre/i.test(t.nodeName) && t.hasAttribute('data-label')) {
+        var n,
+          a,
+          r = t.getAttribute('data-label')
+        try {
+          a = document.querySelector('template#' + r)
+        } catch (e) {}
+        return (
+          a
+            ? (n = a.content)
+            : (t.hasAttribute('data-url')
+                ? ((n = document.createElement('a')).href = t.getAttribute('data-url'))
+                : (n = document.createElement('span')),
+              (n.textContent = r)),
+          n
+        )
+      }
+    }),
+      Prism.hooks.add('complete', t)
+  }
+})()
+!(function () {
+  if ('undefined' != typeof self && self.Prism && self.document)
+    if (Prism.plugins.toolbar) {
+      var i = window.ClipboardJS || void 0
+      i || 'function' != typeof require || (i = require('clipboard'))
+      var u = []
+      if (!i) {
+        var t = document.createElement('script'),
+          e = document.querySelector('head')
+        ;(t.onload = function () {
+          if ((i = window.ClipboardJS)) for (; u.length; ) u.pop()()
+        }),
+          (t.src = 'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js'),
+          e.appendChild(t)
+      }
+      Prism.plugins.toolbar.registerButton('copy-to-clipboard', function (t) {
+        var e = document.createElement('button')
+        ;(e.textContent = 'Copy'), e.setAttribute('type', 'button')
+        var o = t.element
+        return i ? n() : u.push(n), e
+        function n() {
+          var t = new i(e, {
+            text: function () {
+              return o.textContent
+            },
+          })
+          t.on('success', function () {
+            ;(e.textContent = 'Copied!'), r()
+          }),
+            t.on('error', function () {
+              ;(e.textContent = 'Press Ctrl+C to copy'), r()
+            })
+        }
+        function r() {
+          setTimeout(function () {
+            e.textContent = 'Copy'
+          }, 5e3)
+        }
+      })
+    } else console.warn('Copy to Clipboard plugin loaded before Toolbar plugin.')
+})()

--- a/supported.json
+++ b/supported.json
@@ -1,12 +1,6 @@
 {
   "k6-utils": {
-    "versions": [
-      "1.0.0",
-      "1.1.0",
-      "1.2.0",
-      "1.3.0",
-      "1.4.0"
-    ],
+    "versions": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0"],
     "docs-url": "https://k6.io/docs/javascript-api/jslib/utils"
   },
   "k6-summary": {
@@ -17,81 +11,51 @@
     "docs-url": ""
   },
   "jsonpath": {
-    "versions": [
-      "1.0.2"
-    ],
+    "versions": ["1.0.2"],
     "docs-url": "https://github.com/grafana/k6-jslib-JSONPath"
   },
   "formdata": {
-    "versions": [
-      "0.0.1",
-      "0.0.2"
-    ],
+    "versions": ["0.0.1", "0.0.2"],
     "docs-url": ""
   },
   "form-urlencoded": {
-    "versions": [
-      "3.0.0"
-    ],
+    "versions": ["3.0.0"],
     "docs-url": ""
   },
   "papaparse": {
-    "versions": [
-      "5.1.1"
-    ],
+    "versions": ["5.1.1"],
     "docs-url": "https://www.papaparse.com/docs"
   },
   "ajv": {
-    "versions": [
-      "6.12.5"
-    ],
+    "versions": ["6.12.5"],
     "docs-url": "https://ajv.js.org/api.html"
   },
   "httpx": {
-    "versions": [
-      "0.0.1",
-      "0.0.2",
-      "0.0.3",
-      "0.0.4",
-      "0.0.5",
-      "0.0.6"
-    ],
+    "versions": ["0.0.1", "0.0.2", "0.0.3", "0.0.4", "0.0.5", "0.0.6"],
     "docs-url": "https://k6.io/docs/javascript-api/jslib/httpx"
   },
   "expect": {
-    "versions": [
-      "0.0.4",
-      "0.0.5"
-    ],
+    "versions": ["0.0.4", "0.0.5"],
     "docs-url": "https://k6.io/docs/javascript-api/jslib/expect"
   },
   "k6chaijs": {
-    "versions": [
-      "4.3.4.0",
-      "4.3.4.1",
-      "4.3.4.2"
-    ],
+    "versions": ["4.3.4.0", "4.3.4.1", "4.3.4.2"],
     "docs-url": "https://github.com/grafana/k6-jslib-k6chaijs"
   },
   "k6chaijs-contracts": {
-    "versions": [
-      "4.3.4.0"
-    ],
+    "versions": ["4.3.4.0"],
     "docs-url": "https://github.com/grafana/k6-jslib-k6chaijs-contracts"
   },
   "url": {
-    "versions": [
-      "1.0.0"
-    ],
+    "versions": ["1.0.0"],
     "docs-url": ""
   },
   "kahwah": {
-    "versions": [
-      "0.1.6"
-    ],
+    "versions": ["0.1.6"],
     "docs-url": "https://www.npmjs.com/package/kahwah"
   },
   "aws": {
+<<<<<<< HEAD
     "versions": [
       "0.1.0",
       "0.3.0",
@@ -99,6 +63,9 @@
       "0.5.0",
       "0.6.0"
     ],
+=======
+    "versions": ["0.1.0", "0.3.0", "0.4.0", "0.5.0"],
+>>>>>>> Apply imported style rules to relevant files
     "bundle-filename": "aws.js",
     "docs-url": "https://github.com/grafana/k6-jslib-aws"
   }

--- a/tests/ajv-test.js
+++ b/tests/ajv-test.js
@@ -1,9 +1,7 @@
-import Ajv from "../lib/ajv/6.12.5/index.js";
+import Ajv from '../lib/ajv/6.12.5/index.js'
 
 function newAjv() {
-  let ajv = new Ajv();
+  let ajv = new Ajv()
 }
 
-export {
-  newAjv,
-}
+export { newAjv }

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -1,12 +1,12 @@
-import { check } from "k6"
-import http from "k6/http"
+import { check } from 'k6'
+import http from 'k6/http'
 
-import jsonpath from "../lib/jsonpath/1.0.2/index.js";
-import formurlencoded from "../lib/form-urlencoded/3.0.0/index.js";
-import papaparse from "../lib/papaparse/5.1.1/index.js";
-import { describe } from "../lib/kahwah/0.1.6/index.js";
-import { Httpx } from "../lib/httpx/0.0.6/index.js";
-import { initContractPlugin } from "../lib/k6chaijs-contracts/4.3.4.0/index.js";
+import jsonpath from '../lib/jsonpath/1.0.2/index.js'
+import formurlencoded from '../lib/form-urlencoded/3.0.0/index.js'
+import papaparse from '../lib/papaparse/5.1.1/index.js'
+import { describe } from '../lib/kahwah/0.1.6/index.js'
+import { Httpx } from '../lib/httpx/0.0.6/index.js'
+import { initContractPlugin } from '../lib/k6chaijs-contracts/4.3.4.0/index.js'
 import chai, { expect, describe as chaidescribe } from '../lib/k6chaijs/4.3.4.2/index.js'
 import {
   findBetween,
@@ -18,151 +18,145 @@ import {
   getCurrentStageIndex,
   tagWithCurrentStageIndex,
   tagWithCurrentStageProfile,
-} from "../lib/k6-utils/1.4.0/index.js";
+} from '../lib/k6-utils/1.4.0/index.js'
 
 initContractPlugin(chai)
 
 function testJsonPath() {
   const data = {
     user: {
-      name: "Batman"
-    }
-  };
+      name: 'Batman',
+    },
+  }
   check(data, {
-    "jsonpath works": () => jsonpath.value(data, 'user.name') === "Batman"
-  });
+    'jsonpath works': () => jsonpath.value(data, 'user.name') === 'Batman',
+  })
 }
 
 function testPapaparse() {
-  const csvString = "crocodileName;age\nBert;5";
+  const csvString = 'crocodileName;age\nBert;5'
   const config = {
-    header: true
-  };
+    header: true,
+  }
 
-  let parsed = papaparse.parse(csvString, config);
+  let parsed = papaparse.parse(csvString, config)
 
   check(parsed, {
-    "papaparse works": (data) => parsed.data[0].crocodileName === "Bert"
+    'papaparse works': (data) => parsed.data[0].crocodileName === 'Bert',
   })
 }
 
 function testFormurlencoded() {
   const data = {
-    param1: "foo",
-    param2: "bar"
-  };
+    param1: 'foo',
+    param2: 'bar',
+  }
 
   check(data, {
-    "form-urlencoded works": () => formurlencoded(data) === "param1=foo&param2=bar"
-  });
+    'form-urlencoded works': () => formurlencoded(data) === 'param1=foo&param2=bar',
+  })
 }
 
 function testFindBetween() {
-  check(findBetween("**a**", "**", "**"), {
-    "findBetween works": (s) => s === "a",
-  });
+  check(findBetween('**a**', '**', '**'), {
+    'findBetween works': (s) => s === 'a',
+  })
 }
 
 function testNormalDistributionStages() {
   check(normalDistributionStages(1, 1, 1), {
     // This only ensures the function is runnable...not that it is working
-    "normalDistributionStages works": (dist) => dist.length === 3,
-  });
+    'normalDistributionStages works': (dist) => dist.length === 3,
+  })
 }
 
 function testRandomBetween() {
-  let randomInt = randomIntBetween(1, 1);
+  let randomInt = randomIntBetween(1, 1)
 
   check(randomInt, {
-    "randomBetween works": (r) => r === 1,
-  });
+    'randomBetween works': (r) => r === 1,
+  })
 }
 
 function testRandomItem() {
-  let items = [1, 2, 3, 4];
+  let items = [1, 2, 3, 4]
 
   check(randomItem(items), {
-    "randomItem works": (item) => items.includes(item),
-  });
+    'randomItem works': (item) => items.includes(item),
+  })
 }
 
 function testRandomString() {
-  check(randomString(5, "a"), {
-    "randomString works": (s) => s === "aaaaa",
-  });
+  check(randomString(5, 'a'), {
+    'randomString works': (s) => s === 'aaaaa',
+  })
 }
 
 function testuuidv4() {
   check(uuidv4(), {
-    "uuidv4 works": (val) => val.length === 36,
-  });
+    'uuidv4 works': (val) => val.length === 36,
+  })
 }
 
 function testKahwah() {
   check(null, {
-    "kahwah works": (k) => typeof describe == "function",
-  });
+    'kahwah works': (k) => typeof describe == 'function',
+  })
 }
 
 function testGetCurrentStageIndex() {
   check(getCurrentStageIndex, {
-    "getCurrentStageIndex works": (k) => typeof describe == "function",
-  });
+    'getCurrentStageIndex works': (k) => typeof describe == 'function',
+  })
 }
 
 function testTagWithCurrentStageIndex() {
   check(tagWithCurrentStageIndex, {
-    "tagWithCurrentStageIndex works": (k) => typeof describe == "function",
-  });
+    'tagWithCurrentStageIndex works': (k) => typeof describe == 'function',
+  })
 }
 
 function testTagWithCurrentStageProfile() {
   check(tagWithCurrentStageProfile, {
-    "tagWithCurrentStageProfile works": (k) => typeof describe == "function",
-  });
+    'tagWithCurrentStageProfile works': (k) => typeof describe == 'function',
+  })
 }
 
 function testk6chaijs() {
-  chaidescribe("k6 chai js test", () => {
-    expect('k6chaijs').to.equal("k6chaijs")
+  chaidescribe('k6 chai js test', () => {
+    expect('k6chaijs').to.equal('k6chaijs')
   })
 }
 
 function testk6chaijscontracts() {
-
   const crocodileListAPIcontract = {
     items: {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "number"
+      type: 'object',
+      properties: {
+        id: {
+          type: 'number',
         },
-        "name": {
-          "type": "string"
+        name: {
+          type: 'string',
         },
-        "age": {
-          "type": "number",
-          "minimum": 1,
-          "maximum": 1000
+        age: {
+          type: 'number',
+          minimum: 1,
+          maximum: 1000,
         },
-        "date_of_birth": {
-          "type": "string",
-          "format": "date"
-        }
+        date_of_birth: {
+          type: 'string',
+          format: 'date',
+        },
       },
-      "required": [
-        "id",
-        "name",
-        "age",
-        "date_of_birth"
-      ]
-    }
-  };
+      required: ['id', 'name', 'age', 'date_of_birth'],
+    },
+  }
 
   chaidescribe('[Crocs service] Fetch list of crocs', () => {
-    let response = http.get("https://test-api.k6.io/public/crocodiles");
+    let response = http.get('https://test-api.k6.io/public/crocodiles')
     expect(response).to.have.validJsonBody()
-    expect(response.json(), "Croc List schema").to.matchSchema(crocodileListAPIcontract)
+    expect(response.json(), 'Croc List schema').to.matchSchema(crocodileListAPIcontract)
   })
 }
 

--- a/tests/crocFlow.js
+++ b/tests/crocFlow.js
@@ -1,124 +1,122 @@
-import { describe } from '../lib/functional/0.0.3/index.js';
-import { Httpx, Get } from '../lib/httpx/0.0.3/index.js';
-import { randomIntBetween, randomItem, uuidv4 } from "../lib/k6-utils/1.4.0/index.js";
-import { crocodileAPIcontract, crocodileListAPIcontract } from './data/contracts.js';
+import { describe } from '../lib/functional/0.0.3/index.js'
+import { Httpx, Get } from '../lib/httpx/0.0.3/index.js'
+import { randomIntBetween, randomItem, uuidv4 } from '../lib/k6-utils/1.4.0/index.js'
+import { crocodileAPIcontract, crocodileListAPIcontract } from './data/contracts.js'
 
-const USERNAME = `user${uuidv4()}@example.com`;  // Set your own email;
-const PASSWORD = 'superCroc2019';
+const USERNAME = `user${uuidv4()}@example.com` // Set your own email;
+const PASSWORD = 'superCroc2019'
 
-let session = new Httpx({baseURL: 'https://test-api.k6.io'});
+let session = new Httpx({ baseURL: 'https://test-api.k6.io' })
 
 function CrocFlow() {
-
   describe('Fetch public crocs', (t) => {
-    let responses = session.batch([
-      new Get('/public/crocodiles/1/'),
-      new Get('/public/crocodiles/2/'),
-      new Get('/public/crocodiles/3/'),
-      new Get('/public/crocodiles/4/'),
-    ], {
-      tags: {name: 'PublicCrocs'},
-    });
+    let responses = session.batch(
+      [
+        new Get('/public/crocodiles/1/'),
+        new Get('/public/crocodiles/2/'),
+        new Get('/public/crocodiles/3/'),
+        new Get('/public/crocodiles/4/'),
+      ],
+      {
+        tags: { name: 'PublicCrocs' },
+      }
+    )
 
-    responses.forEach(response => {
-      t.expect(response.status).as("response status").toEqual(200)
-        .and(response).toHaveValidJson()
-        .and(response.json()).toMatchAPISchema(crocodileAPIcontract)
-        .and(response.json('age')).as('croc age').toBeGreaterThan(7);
-    });
-  })
+    responses.forEach((response) => {
+      t.expect(response.status)
+        .as('response status')
+        .toEqual(200)
+        .and(response)
+        .toHaveValidJson()
+        .and(response.json())
+        .toMatchAPISchema(crocodileAPIcontract)
+        .and(response.json('age'))
+        .as('croc age')
+        .toBeGreaterThan(7)
+    })
+  }) &&
+    describe(`Create a test user ${USERNAME}`, (t) => {
+      let resp = session.post(`/user/register/`, {
+        first_name: 'Crocodile',
+        last_name: 'Owner',
+        username: USERNAME,
+        password: PASSWORD,
+      })
 
-  &&
+      t.expect(resp.status).as('status').toEqual(201).and(resp).toHaveValidJson()
+    }) &&
+    describe(`Authenticate the new user ${USERNAME}`, (t) => {
+      let resp = session.post(`/auth/token/login/`, {
+        username: USERNAME,
+        password: PASSWORD,
+      })
 
-  describe(`Create a test user ${USERNAME}`, (t) => {
+      t.expect(resp.status)
+        .as('Auth status')
+        .toBeBetween(200, 204)
+        .and(resp)
+        .toHaveValidJson()
+        .and(resp.json('access'))
+        .as('auth token')
+        .toBeTruthy()
 
-    let resp = session.post(`/user/register/`, {
-      first_name: 'Crocodile',
-      last_name: 'Owner',
-      username: USERNAME,
-      password: PASSWORD,
-    });
+      let authToken = resp.json('access')
+      // set the authorization header on the session for the subsequent requests.
+      session.addHeader('Authorization', `Bearer ${authToken}`)
+    })
 
-    t.expect(resp.status).as("status").toEqual(201)
-      .and(resp).toHaveValidJson();
-  })
-
-  &&
-
-  describe(`Authenticate the new user ${USERNAME}`, (t) => {
-
-    let resp = session.post(`/auth/token/login/`, {
-      username: USERNAME,
-      password: PASSWORD
-    });
-
-    t.expect(resp.status).as("Auth status").toBeBetween(200, 204)
-      .and(resp).toHaveValidJson()
-      .and(resp.json('access')).as("auth token").toBeTruthy();
-
-    let authToken = resp.json('access');
-    // set the authorization header on the session for the subsequent requests.
-    session.addHeader('Authorization', `Bearer ${authToken}`);
-
-  });
-
-  let newCrocId = null;
+  let newCrocId = null
 
   describe('Create a new crocodile', (t) => {
     let payload = {
       name: `Croc Name`,
-      sex: randomItem(["M", "F"]),
+      sex: randomItem(['M', 'F']),
       date_of_birth: '2019-01-01',
-    };
+    }
 
-    let resp = session.post(`/my/crocodiles/`, payload);
+    let resp = session.post(`/my/crocodiles/`, payload)
 
-    t.expect(resp.status).as("Croc creation status").toEqual(201)
-      .and(resp).toHaveValidJson();
+    t.expect(resp.status).as('Croc creation status').toEqual(201).and(resp).toHaveValidJson()
 
-    newCrocId=resp.json('id');
-  })
+    newCrocId = resp.json('id')
+  }) &&
+    describe('Fetch private crocs', (t) => {
+      let response = session.get('/my/crocodiles/')
 
-  &&
+      t.expect(response.status)
+        .as('response status')
+        .toEqual(200)
+        .and(response)
+        .toHaveValidJson()
+        .and(response.json().length)
+        .as('number of crocs')
+        .toEqual(1)
+        .and(response.json())
+        .toMatchAPISchema(crocodileListAPIcontract)
+    }) &&
+    describe('Update the croc', (t) => {
+      let payload = {
+        name: `New name`,
+      }
 
-  describe('Fetch private crocs', (t) => {
+      let resp = session.patch(`/my/crocodiles/${newCrocId}/`, payload)
 
-    let response = session.get('/my/crocodiles/');
+      t.expect(resp.status)
+        .as('Croc patch status')
+        .toEqual(200)
+        .and(resp)
+        .toHaveValidJson()
+        .and(resp.json('name'))
+        .as('name')
+        .toEqual('New name')
 
-    t.expect(response.status).as("response status").toEqual(200)
-      .and(response).toHaveValidJson()
-      .and(response.json().length).as("number of crocs").toEqual(1)
-      .and(response.json()).toMatchAPISchema(crocodileListAPIcontract);
-  })
+      let resp1 = session.get(`/my/crocodiles/${newCrocId}/`)
+    }) &&
+    describe('Delete the croc', (t) => {
+      let resp = session.delete(`/my/crocodiles/${newCrocId}/`)
 
-  &&
-
-  describe('Update the croc', (t) => {
-    let payload = {
-      name: `New name`,
-    };
-
-    let resp = session.patch(`/my/crocodiles/${newCrocId}/`, payload);
-
-    t.expect(resp.status).as("Croc patch status").toEqual(200)
-      .and(resp).toHaveValidJson()
-      .and(resp.json('name')).as('name').toEqual('New name');
-
-    let resp1 = session.get(`/my/crocodiles/${newCrocId}/`);
-
-  })
-
-  &&
-
-  describe('Delete the croc', (t) => {
-
-    let resp = session.delete(`/my/crocodiles/${newCrocId}/`);
-
-    t.expect(resp.status).as("Croc delete status").toEqual(204);
-  });
-
+      t.expect(resp.status).as('Croc delete status').toEqual(204)
+    })
 }
 
-export {
-  CrocFlow
-}
+export { CrocFlow }

--- a/tests/formdata.js
+++ b/tests/formdata.js
@@ -1,31 +1,42 @@
-var http = require('k6/http');
+var http = require('k6/http')
 var check = require('k6').check
-var FormData = require('../lib/formdata/0.0.2/index.js').FormData;
+var FormData = require('../lib/formdata/0.0.2/index.js').FormData
 
-var logo = open('./data/logo.png', 'b');
+var logo = open('./data/logo.png', 'b')
 
-exports.testPost = function() {
-  var fd = new FormData();
-  fd.append('binArray', http.file(logo, 'logo.png', 'image/png'));
-  fd.append('ArrayBuffer', { data: new Uint8Array(logo).buffer, filename: 'logo.png', content_type: 'image/png' });
-  fd.append('text', http.file('hello', 'hello.txt', 'text/plain'));
-  fd.append('textField', 'world');
-  fd.append('anotherField', '!');
-  var res = http.post('https://httpbin.test.k6.io/post', fd.body(),
-                      { headers: { 'Content-Type': 'multipart/form-data; boundary=' + fd.boundary }});
+exports.testPost = function () {
+  var fd = new FormData()
+  fd.append('binArray', http.file(logo, 'logo.png', 'image/png'))
+  fd.append('ArrayBuffer', {
+    data: new Uint8Array(logo).buffer,
+    filename: 'logo.png',
+    content_type: 'image/png',
+  })
+  fd.append('text', http.file('hello', 'hello.txt', 'text/plain'))
+  fd.append('textField', 'world')
+  fd.append('anotherField', '!')
+  var res = http.post('https://httpbin.test.k6.io/post', fd.body(), {
+    headers: { 'Content-Type': 'multipart/form-data; boundary=' + fd.boundary },
+  })
   var checks = {
-    'got 200 response': function (res) { return res.status === 200 },
+    'got 200 response': function (res) {
+      return res.status === 200
+    },
     'form fields were submitted correctly': function (res) {
-      var form = res.json()['form'];
-      return form.textField == 'world' && form.anotherField == '!';
+      var form = res.json()['form']
+      return form.textField == 'world' && form.anotherField == '!'
     },
     'files were uploaded correctly': function (res) {
-      var files = res.json()['files'];
-      return (Object.keys(files).length === 3 &&
-              (files['binArray'] && files['binArray'].includes('image/png')) &&
-              (files['ArrayBuffer'] && files['ArrayBuffer'].includes('image/png')) &&
-              (files['binArray'] == files['ArrayBuffer']) &&
-              (files['text'] == 'hello'));
+      var files = res.json()['files']
+      return (
+        Object.keys(files).length === 3 &&
+        files['binArray'] &&
+        files['binArray'].includes('image/png') &&
+        files['ArrayBuffer'] &&
+        files['ArrayBuffer'].includes('image/png') &&
+        files['binArray'] == files['ArrayBuffer'] &&
+        files['text'] == 'hello'
+      )
     },
   }
   check(res, checks)

--- a/tests/httpx.js
+++ b/tests/httpx.js
@@ -1,41 +1,34 @@
-import { check } from 'k6';
-import { Httpx, Get } from "../lib/httpx/0.0.6/index.js";
-import { describe } from '../lib/expect/0.0.4/index.js';
+import { check } from 'k6'
+import { Httpx, Get } from '../lib/httpx/0.0.6/index.js'
+import { describe } from '../lib/expect/0.0.4/index.js'
 
 function httpxBatchTest() {
-  let session = new Httpx({baseURL: 'https://test-api.k6.io'});
+  let session = new Httpx({ baseURL: 'https://test-api.k6.io' })
 
-  let responses = session.batch([
-    new Get('/public/crocodiles/3/'),
-    new Get('/public/crocodiles/4/'),
-  ], {
-    tags: {name: 'PublicCrocs'},
-  });
+  let responses = session.batch(
+    [new Get('/public/crocodiles/3/'), new Get('/public/crocodiles/4/')],
+    {
+      tags: { name: 'PublicCrocs' },
+    }
+  )
 
-  responses.forEach(response => {
+  responses.forEach((response) => {
     check(response, {
-      'httpx valid status': (r) => r.status === 200
+      'httpx valid status': (r) => r.status === 200,
     })
-  });
+  })
 }
 
 function httpxTestAbsoluteURLs() {
-  let session = new Httpx({ baseURL: 'https://test-api.k6.io' });
+  let session = new Httpx({ baseURL: 'https://test-api.k6.io' })
 
   describe('Absolute URLs override the baseURL', (t) => {
-    let relativeURL = session.get('/public/crocodiles/1'); //
-    let absoluteURL = session.get('https://httpbin.test.k6.io/get'); // should work.
+    let relativeURL = session.get('/public/crocodiles/1') //
+    let absoluteURL = session.get('https://httpbin.test.k6.io/get') // should work.
 
-    t.expect(relativeURL.status).as("relative URL").toEqual(200);
-    t.expect(absoluteURL.status).as("absolute URL").toEqual(200);
-  });
-
+    t.expect(relativeURL.status).as('relative URL').toEqual(200)
+    t.expect(absoluteURL.status).as('absolute URL').toEqual(200)
+  })
 }
 
-
-export {
-  httpxBatchTest,
-  httpxTestAbsoluteURLs,
-}
-
-
+export { httpxBatchTest, httpxTestAbsoluteURLs }

--- a/tests/papaparseRedingFile.js
+++ b/tests/papaparseRedingFile.js
@@ -1,18 +1,14 @@
-import papaparse from "../lib/papaparse/5.1.1/index.js";
+import papaparse from '../lib/papaparse/5.1.1/index.js'
 
-const csvData = papaparse.parse(open('./data/sampleCSV-100-rows.csv'), { header: true });
+const csvData = papaparse.parse(open('./data/sampleCSV-100-rows.csv'), { header: true })
 
 function papaparseTest() {
-
-  let randomUser = csvData.data[Math.floor(Math.random() * csvData.data.length)];
+  let randomUser = csvData.data[Math.floor(Math.random() * csvData.data.length)]
 
   const params = {
     login: randomUser.username,
     password: randomUser.password,
-  };
+  }
 }
 
-export {
-  papaparseTest
-}
-
+export { papaparseTest }

--- a/tests/response-time.js
+++ b/tests/response-time.js
@@ -1,33 +1,33 @@
-import { sleep } from "k6";
-import http from "k6/http";
+import { sleep } from 'k6'
+import http from 'k6/http'
 
 export let options = {
-  duration: "2m",
+  duration: '2m',
   vus: 20,
   ext: {
     loadimpact: {
       distribution: {
-        us: { loadZone: "amazon:us:ashburn", percent: 25 },
-        uk: { loadZone: "amazon:gb:london", percent: 25 },
-        eu: { loadZone: "amazon:de:frankfurt", percent: 25 },
-        asia: { loadZone: "amazon:jp:tokyo", percent: 25 }
-      }
-    }
-  }
-};
-
-const TEST_URL_CDN = "http://k6-simon-cdn.loadimpact.com/jsonpath/1.0.2/index.js";
-const TEST_URL_NO_CDN = "http://k6-simon.loadimpact.com/jsonpath/1.0.2/index.js";
-
-function requestSpec(url, tags) {
-  return ["GET", url, null, { tags }];
+        us: { loadZone: 'amazon:us:ashburn', percent: 25 },
+        uk: { loadZone: 'amazon:gb:london', percent: 25 },
+        eu: { loadZone: 'amazon:de:frankfurt', percent: 25 },
+        asia: { loadZone: 'amazon:jp:tokyo', percent: 25 },
+      },
+    },
+  },
 }
 
-export default function() {
+const TEST_URL_CDN = 'http://k6-simon-cdn.loadimpact.com/jsonpath/1.0.2/index.js'
+const TEST_URL_NO_CDN = 'http://k6-simon.loadimpact.com/jsonpath/1.0.2/index.js'
+
+function requestSpec(url, tags) {
+  return ['GET', url, null, { tags }]
+}
+
+export default function () {
   http.batch([
     requestSpec(TEST_URL_CDN, { cdn: true }),
-    requestSpec(TEST_URL_NO_CDN, { cdn: false })
-  ]);
+    requestSpec(TEST_URL_NO_CDN, { cdn: false }),
+  ])
 
-  sleep(1);
+  sleep(1)
 }

--- a/tests/testSuite.js
+++ b/tests/testSuite.js
@@ -24,16 +24,32 @@ import {
   testk6chaijscontracts,
 } from './basic.js'
 
-let testCasesOK = new Rate('test_case_ok');
+let testCasesOK = new Rate('test_case_ok')
 
 const testCases = [
-  URLWebAPI, testJsonPath, testFormurlencoded, testPapaparse, testRandomBetween,
-  testRandomItem, testuuidv4,
-  testGetCurrentStageIndex, testTagWithCurrentStageIndex, testTagWithCurrentStageProfile,
-  papaparseTest, httpxBatchTest, newAjv, CrocFlow,
-  testKahwah, httpxTestAbsoluteURLs, testk6chaijs, testk6chaijscontracts,
-  testFindBetween, testNormalDistributionStages, testRandomString, testAWS
-];
+  URLWebAPI,
+  testJsonPath,
+  testFormurlencoded,
+  testPapaparse,
+  testRandomBetween,
+  testRandomItem,
+  testuuidv4,
+  testGetCurrentStageIndex,
+  testTagWithCurrentStageIndex,
+  testTagWithCurrentStageProfile,
+  papaparseTest,
+  httpxBatchTest,
+  newAjv,
+  CrocFlow,
+  testKahwah,
+  httpxTestAbsoluteURLs,
+  testk6chaijs,
+  testk6chaijscontracts,
+  testFindBetween,
+  testNormalDistributionStages,
+  testRandomString,
+  testAWS,
+]
 
 export const options = {
   vus: 1,
@@ -46,11 +62,11 @@ export const options = {
 
 export default function () {
   try {
-    testCases[__ITER]();
-    testCasesOK.add(true);
+    testCases[__ITER]()
+    testCasesOK.add(true)
   } catch (e) {
-    testCasesOK.add(false);
+    testCasesOK.add(false)
     console.log(`test case at index ${__ITER} has failed`)
-    throw e;
+    throw e
   }
 }

--- a/tests/uuid-performance.js
+++ b/tests/uuid-performance.js
@@ -1,13 +1,13 @@
-import { sleep } from "k6";
-import { uuidv4 }from "../lib/k6-utils/1.4.0/index.js";
+import { sleep } from 'k6'
+import { uuidv4 } from '../lib/k6-utils/1.4.0/index.js'
 
 export let options = {
   duration: '1m',
   vus: 1,
-};
+}
 
 // number of iterations = number of times the function executed
 // 1.3M executions in 60 seconds on my laptop
-export default function() {
-  uuidv4();
+export default function () {
+  uuidv4()
 }


### PR DESCRIPTION
Whenever I would have to work with the jslib.k6.io repository, I would encounter issues and conflicts with my own vscode's eslint and prettier configuration (aligned with the k6-docs') who would enforce the reformatting of files all around.

To avoid this recurring issue, and align the way our javascript is written across all our projects, this PR imports the eslint, and prettier configuration from the k6-docs, and applies them to the whole repository.

The `lib/` folder is explicitly ignored by both to avoid reformatting bundle and minified files.