### PR TITLE
Add new k6-rails v0.1.0 lib

### DIFF
--- a/lib/index.html
+++ b/lib/index.html
@@ -630,6 +630,10 @@ export default function() {
       <td>aws</td>
       <td><a target="_blank" href="https://jslib.k6.io/aws/0.1.0/aws.js">0.1.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.3.0/aws.js">0.3.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.4.0/aws.js">0.4.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.5.0/aws.js">0.5.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.6.0/aws.js">0.6.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.7.0/aws.js">0.7.0</a></td>
       <td><a href="https://github.com/grafana/k6-jslib-aws">https://github.com/grafana/k6-jslib-aws</a></td>
+    </tr><tr>
+      <td>k6-rails</td>
+      <td><a target="_blank" href="https://jslib.k6.io/k6-rails/0.1.0/index.js">0.1.0</a></td>
+      <td></td>
     </tr>
     </table>
   
@@ -1299,4 +1303,3 @@ Prism.languages.clike = {
       </script>
     </body>
     </html>
-  

--- a/lib/k6-rails/0.1.0/index.js
+++ b/lib/k6-rails/0.1.0/index.js
@@ -1,0 +1,30 @@
+// Find and return the Turbo stream name
+export function turboStreamName(doc) {
+  let el = doc.find("turbo-cable-stream-source");
+  if (!el) return;
+
+  return el.attr("signed-stream-name");
+}
+
+// Find and return action-cable-url on the page
+export function cableUrl(doc) {
+  return fetchMeta(doc, 'name', 'action-cable-url')
+}
+
+// Find and return csrf-token on the page
+export function csrfToken(doc) {
+  return fetchMeta(doc, 'name', 'csrf-token')
+}
+
+// Find and return csrf-param on the page
+export function csrfParam(doc) {
+  return fetchMeta(doc, 'name', 'csrf-param')
+}
+
+// Find and return meta attributes' value
+export function fetchMeta(doc, attr, attrVal, attrContent = 'content') {
+  let el = doc.find(`meta[${attr.toString()}=${attrVal.toString()}]`)
+  if (!el) return;
+
+  return el.attr(attrContent.toString())
+}

--- a/supported.json
+++ b/supported.json
@@ -55,5 +55,9 @@
     "versions": ["0.1.0", "0.3.0", "0.4.0", "0.5.0", "0.6.0", "0.7.0"],
     "bundle-filename": "aws.js",
     "docs-url": "https://github.com/grafana/k6-jslib-aws"
+  },
+  "k6-rails": {
+    "versions": ["0.1.0"],
+    "docs-url": ""
   }
 }

--- a/tests/k6-rails.js
+++ b/tests/k6-rails.js
@@ -1,0 +1,71 @@
+import { check } from 'k6'
+
+import { turboStreamName, cableUrl, csrfToken, csrfParam, fetchMeta } from '../lib/k6-rails/0.1.0/index.js';
+
+function testTurboStreamName() {
+  const mockedData = {
+    find: (_) => {
+        return { attr: (_) => 'test name' }
+    }
+  };
+
+  check(turboStreamName(mockedData), {
+    'turboStreamName works': (r) => r === 'test name'
+  })
+}
+
+function testCableUrl() {
+  const mockedData = {
+    find: (_) => {
+      return { attr: (_) => 'cable url' }
+    }
+  }
+
+  check(cableUrl(mockedData), {
+    'cableUrl works': (r) => r === 'cable url'
+  })
+}
+
+function testCsrfToken() {
+  const mockedData = {
+    find: (_) => {
+      return { attr: (_) => 'csrf-token' }
+    }
+  }
+
+  check(csrfToken(mockedData), {
+    'csrfToken works': (r) =>  r === 'csrf-token'
+  })
+}
+
+function testCsrfParam() {
+  const mockedData = {
+    find: (_) => {
+      return { attr: (_) => 'csrf-param' }
+    }
+  }
+
+  check(csrfParam(mockedData), {
+    'csrfToken works': (r) =>  r === 'csrf-param'
+  })
+}
+
+function testFetchMeta() {
+  const mockedData = {
+    find: (_) => {
+      return { attr: (_) => 'width=device-width, initial-scale=1' }
+    }
+  }
+
+  check(fetchMeta(mockedData, 'name', 'viewport', 'content'), {
+    'fetchMeta works': (r) => r === 'width=device-width, initial-scale=1'
+  })
+}
+
+export {
+  testTurboStreamName,
+  testCableUrl,
+  testCsrfToken,
+  testCsrfParam,
+  testFetchMeta,
+}

--- a/tests/testSuite.js
+++ b/tests/testSuite.js
@@ -6,6 +6,7 @@ import { newAjv } from './ajv-test.js'
 import { CrocFlow } from './crocFlow.js'
 import { URLWebAPI } from './url.js'
 import { testAWS } from './aws.js'
+import { testTurboStreamName, testCableUrl, testCsrfToken, testCsrfParam, testFetchMeta } from './k6-rails.js'
 import {
   testJsonPath,
   testFormurlencoded,
@@ -49,6 +50,11 @@ const testCases = [
   testNormalDistributionStages,
   testRandomString,
   testAWS,
+  testTurboStreamName,
+  testCableUrl,
+  testCsrfToken,
+  testCsrfParam,
+  testFetchMeta,
 ]
 
 export const options = {


### PR DESCRIPTION
## Description

Adds k6-rails lib with helpers for Rails.

- [x] The Pull Request creates a `/lib/k6-rails` folder.
- [x] The Pull Request creates a `/lib/k6-rails/0.1.0` folder.
- [x] The `/lib/k6-rails/0.1.0/index.js` file containing the jslib's code bundle exists.
- [x] The Pull Request updates the `supported.json` file to contain an entry for the newly added jslib and its `0.1.0`, as in the following example:
```JSON
{
  "k6-rails": {
    "versions": [
      "0.1.0"
    ],
  }
}
```
- [x] Tests have been added to `/tests/testSuite.js` to ensure that the added jslib is importable and runnable by k6.