### PR TITLE
Added steadybit extension

### DIFF
--- a/lib/index.html
+++ b/lib/index.html
@@ -630,6 +630,10 @@ export default function() {
       <td>aws</td>
       <td><a target="_blank" href="https://jslib.k6.io/aws/0.1.0/aws.js">0.1.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.3.0/aws.js">0.3.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.4.0/aws.js">0.4.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.5.0/aws.js">0.5.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.6.0/aws.js">0.6.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.7.0/aws.js">0.7.0</a>, <a target="_blank" href="https://jslib.k6.io/aws/0.7.1/aws.js">0.7.1</a></td>
       <td><a href="https://k6.io/docs/javascript-api/jslib/aws/">https://k6.io/docs/javascript-api/jslib/aws/</a></td>
+    </tr><tr>
+      <td>steadybit</td>
+      <td><a target="_blank" href="https://jslib.k6.io/steadybit/1.0.0/index.js">1.0.0</a></td>
+      <td><a href="https://github.com/steadybit/k6-extension">https://github.com/steadybit/k6-extension</a></td>
     </tr>
     </table>
   

--- a/lib/steadybit/1.0.0/index.js
+++ b/lib/steadybit/1.0.0/index.js
@@ -1,0 +1,75 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export class Client {
+    constructor(accessKey = (__ENV.STEADYBIT_ACCESS_KEY || __ENV.STEADYBIT_TOKEN), platformUrl = 'https://platform.steadybit.io') {
+        this.platformUrl = platformUrl;
+        this.headers = {
+            'Authorization': `accessToken ${accessKey}`,
+            'Accept': 'application/json',
+            'User-Agent': 'steadybit/k6'
+        };
+    }
+
+    start(experimentKey, allowParallel = false) {
+        const response = http.post(`${this.platformUrl}/api/experiments/${experimentKey}/execute?allowParallel=${allowParallel}`, null, { headers: this.headers, tags: {} });
+        if (response.status === 201) {
+            let execution = response.headers['Location'];
+            this.verifyRunning(execution);
+            return execution;
+        } else {
+            const title = response.json('title');
+            if (title) {
+                throw new Error(title);
+            } else {
+                throw new Error(`Unexpected response status: ${response.status}`);
+            }
+        }
+    }
+
+    cancel(executionUrl) {
+        const response = http.delete(executionUrl, { headers: this.headers });
+        if (response.status !== 200) {
+            throw new Error(`Unexpected response status: ${response.status}`);
+        }
+    }
+
+    verifyCompleted(executionUrl, timeout = 60) {
+        const state = this.waitForEnd(executionUrl, timeout);
+        if (state !== 'COMPLETED') {
+            throw new Error(`Execution did not complete within ${timeout}s. State: ${state}`);
+        }
+    }
+
+    verifyRunning(executionUrl, timeout = 60) {
+        const state = this.waitForState(executionUrl, timeout, 'RUNNING', 'COMPLETED', 'CANCELED', 'FAILED');
+        if (state !== 'RUNNING') {
+            throw new Error(`Execution did not start within ${timeout}s. State: ${state}`);
+        }
+    }
+
+    waitForEnd(executionUrl, timeout = 60) {
+        return this.waitForState(executionUrl, timeout, 'COMPLETED', 'CANCELED', 'FAILED');
+    }
+
+    waitForState(executionUrl, timeout, ...states) {
+        const deadline = new Date().getTime() + (timeout * 1000);
+        let state = 'UNKNOWN';
+        while (new Date().getTime() < deadline && !states.includes(state)) {
+            state = this.getState(executionUrl);
+            sleep(1)
+        }
+        return state;
+    }
+
+    getState(executionUrl) {
+        const response = http.get(executionUrl, { headers: this.headers });
+        if (response.status === 200) {
+            return response.json('state');
+        } else {
+            throw new Error(`Unexpected response status: ${response.status}`);
+        }
+    }
+}
+
+export default new Client();

--- a/supported.json
+++ b/supported.json
@@ -55,5 +55,9 @@
     "versions": ["0.1.0", "0.3.0", "0.4.0", "0.5.0", "0.6.0", "0.7.0", "0.7.1"],
     "bundle-filename": "aws.js",
     "docs-url": "https://k6.io/docs/javascript-api/jslib/aws/"
+  },
+  "steadybit": {
+    "versions": ["1.0.0"],
+    "docs-url": "https://github.com/steadybit/k6-extension"
   }
 }

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -20,6 +20,7 @@ import {
   tagWithCurrentStageIndex,
   tagWithCurrentStageProfile,
 } from '../lib/k6-utils/1.4.0/index.js'
+import steadybit from '../lib/steadybit/1.0.0/index.js'
 
 initContractPlugin(chai)
 
@@ -155,6 +156,24 @@ function testk6chaijscontracts() {
   })
 }
 
+function testSteadybit() {
+	// We can't really test the underlying steadybit implementation without access to a server instance.
+	// So let's just verify that everything is properly imported, and that the expected public symbols exist.
+	check(steadybit, {
+		'steadybit works': (s) => {
+			console.log(typeof s.start)
+			return typeof s == 'object' &&
+				typeof s.start == 'function' &&
+				typeof s.verifyCompleted == 'function' &&
+				typeof s.verifyRunning == 'function' &&
+				typeof s.waitForState == 'function' &&
+				typeof s.waitForEnd == 'function' &&
+				typeof s.cancel == 'function' &&
+				typeof s.getState == 'function'
+		},
+	})
+}
+
 export {
   testJsonPath,
   testFormurlencoded,
@@ -171,4 +190,5 @@ export {
   testTagWithCurrentStageProfile,
   testk6chaijs,
   testk6chaijscontracts,
+  testSteadybit
 }

--- a/tests/testSuite.js
+++ b/tests/testSuite.js
@@ -22,6 +22,7 @@ import {
   testTagWithCurrentStageProfile,
   testk6chaijs,
   testk6chaijscontracts,
+  testSteadybit
 } from './basic.js'
 
 let testCasesOK = new Rate('test_case_ok')
@@ -49,6 +50,7 @@ const testCases = [
   testNormalDistributionStages,
   testRandomString,
   testAWS,
+  testSteadybit
 ]
 
 export const options = {


### PR DESCRIPTION
## Description

Added a lib to start [Steadybit](https://steadybit.com/) experiments from within k6 scripts.

Steadybit already [supports starting k6 scripts](https://hub.steadybit.com/action/loadtest:k6) from within its experiments. This PR allows the other way around.

## Please fill in this template.

- [x] Use a meaningful title for the Pull Request. Include the name of the jslib added/modified.
- [x] Fill the description section of the Pull Request. 
- [x] Test the change in your code, and ensure the `npm run test` command succeeds.
- [x] Run `yarn run generate-homepage` locally and verify the new homepage `/lib/index.html` file looks legit.
- [x] The Pull Request creates a `/lib/{jslib_name}` folder.
- [x] The Pull Request creates a `/lib/{jslib_name}/{desired_version}` folder.
- [x] The `/lib/{jslib_name}/{desired_version}/index.js` file containing the jslib's code bundle exists.
- [x] The Pull Request updates the `supported.json` file to contain an entry for the newly added jslib and its `{desired_version}`, as in the following example:
```JSON
{
  "{jslib_name}": {
    // Available package versions
    "versions": [
      "{desired_version}"
    ],

    // (optional) Documentation's or repository's URL
    "docs-url": "{documentation_or_repository_url}",

    // (optional) As a default, the homepage will point to
    // a package's bundle's index.js. If your package's main
    // bundle name is different; set it here (see the AWS
    // package for instance).
    "bundle-filename": "{index.js}"
}
```
- [x] Tests have been added to `/tests/basic.js` and `/tests/testSuite.js` to ensure that the added jslib is importable and runnable by k6.
