### PR TITLE
Issues auto-assigner

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -1,0 +1,76 @@
+name: "Auto assign maintainer to issue"
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  assign-user:
+    runs-on: ubuntu-latest
+    # issue_comment triggers for both, issues and prs,
+    # as we need to run only on issues, it filter out prs.
+    if: ${{ !github.event.issue.pull_request }}
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const assigneeCount = 1;
+            
+            const core = {
+              assignees: ['mstoykov', 'codebien', 'olegbespalov', 'oleiade', 'joanlopez'],
+              keywords: ['utils', 'summary', 'httpx', 'url'],
+            }
+            const frontend = {
+              assignees: ['legander', 'w1kman', 'allansson', 'going-confetti', '2Steaks', 'e-fisher', 'EdvinasDaugirdas'],
+              keywords: ['jsonpath', 'urlencoded', 'chaijs', 'paparse', 'ajv'],
+            }
+            
+            const teams = [core, frontend]
+            const allAssignees = teams.flatMap((team) => team.assignees);
+
+            // Do not automatically assign users if someone was already assigned or it was opened by a maintainer
+            if (context.payload.issue.assignees.length > 0 || allAssignees.includes(context.actor)) {
+              return;
+            }
+            const crypto = require("node:crypto");
+
+            const getNRandom = (n, array) => {
+              let result = new Array();
+              for (;n > 0 && array.length > 0; n--) {
+                const chosen = array[crypto.randomInt(array.length)];
+                result.push(chosen);
+                array = array.filter(el => el != chosen);
+              }
+              return result;
+            }
+
+            const pickAssignees = (n, teams, title) => {
+              let assignees = teams
+                .filter((team) => team.keywords.some((keyword) => title.includes(keyword)))
+                .flatMap((team) => team.assignees)
+
+              if (assignees.length == 0) {
+                assignees = teams.flatMap((team) => team.assignees)
+              }
+
+              return getNRandom(n, assignees)
+            }
+
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["triage"]
+            });
+
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: pickAssignees(assigneeCount, teams, context.issue.title),
+            });
+            


### PR DESCRIPTION
# What?

I've noticed that there some issues in this repo that weren't triaged. As part as the process optimisation I'm introducing a workflow that will auto assign the maintainer based on the keywords (they extracted from the owned repository names).

It's inspired by the one that we have in k6 https://github.com/grafana/k6/blob/master/.github/workflows/issue-auto-assign.yml

# Why?

That way we have less chances to miss if there is a feedback/question/bug or whatsoever.