### PR TITLE
Fix http-instrumentation-pyroscope not using `name` tag

### DIFF
--- a/lib/http-instrumentation-pyroscope/1.0.0/index.js
+++ b/lib/http-instrumentation-pyroscope/1.0.0/index.js
@@ -8,7 +8,7 @@ const request = http.request;
 const asyncRequest = http.asyncRequest;
 
 function pyroBaggage(url, _, params) {
-  return { baggage: `k6.test_run_id=${__ENV.K6_CLOUDRUN_TEST_RUN_ID}, k6.scenario=${execution.scenario.name}, k6.name=${params?.name ? params.name : url}` }
+  return { baggage: `k6.test_run_id=${__ENV.K6_CLOUDRUN_TEST_RUN_ID}, k6.scenario=${execution.scenario.name}, k6.name=${params?.tags?.name ? params.tags.name : url}` }
 }
 
 class Client {

--- a/lib/http-instrumentation-pyroscope/1.0.1/index.js
+++ b/lib/http-instrumentation-pyroscope/1.0.1/index.js
@@ -8,7 +8,7 @@ const request = http.request;
 const asyncRequest = http.asyncRequest;
 
 function pyroBaggage(url, _, params) {
-  return { baggage: `k6.test_run_id=${__ENV.K6_CLOUDRUN_TEST_RUN_ID}, k6.scenario=${execution.scenario.name}, k6.name=${params?.name ? params.name : url}` }
+  return { baggage: `k6.test_run_id=${__ENV.K6_CLOUDRUN_TEST_RUN_ID}, k6.scenario=${execution.scenario.name}, k6.name=${params?.tags?.name ? params.tags.name : url}` }
 }
 
 class Client {

--- a/lib/index.html
+++ b/lib/index.html
@@ -632,7 +632,7 @@ export default function() {
       <td><a href="https://grafana.com/docs/k6/latest/javascript-api/jslib/aws">https://grafana.com/docs/k6/latest/javascript-api/jslib/aws</a></td>
     </tr><tr>
       <td>http-instrumentation-pyroscope</td>
-      <td><a target="_blank" href="https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js">1.0.0</a></td>
+      <td><a target="_blank" href="https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js">1.0.0</a>, <a target="_blank" href="https://jslib.k6.io/http-instrumentation-pyroscope/1.0.1/index.js">1.0.1</a></td>
       <td><a href="https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-pyroscope/">https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-pyroscope/</a></td>
     </tr><tr>
       <td>http-instrumentation-tempo</td>

--- a/supported.json
+++ b/supported.json
@@ -80,7 +80,7 @@
     "docs-url": "https://grafana.com/docs/k6/latest/javascript-api/jslib/aws"
   },
   "http-instrumentation-pyroscope": {
-    "versions": ["1.0.0"],
+    "versions": ["1.0.0", "1.0.1"],
     "docs-url": "https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-pyroscope/"
   },
   "http-instrumentation-tempo": {


### PR DESCRIPTION
## Description

the `name` tag was not accessed properly

Fix found by @andrewslotin

## Please fill in this template.

- [ ] Use a meaningful title for the Pull Request. Include the name of the jslib added/modified.
- [ ] Fill the description section of the Pull Request. 
- [ ] Test the change in your code, and ensure the `npm run test` command succeeds.
- [ ] Run `yarn run generate-homepage` locally and verify the new homepage `/lib/index.html` file looks legit.

**Select one of these and delete the others**:

*If publishing a new version of an existing jslib*:
- [ ] The Pull Request is labeled with the `version bump` label.
- [ ] The Pull Request adds a `/lib/{jslib_name}/{desired_version}` folder.
- [ ] The Pull Request adds a `/lib/{jslib_name}/{desired_version}/index.js` file containing the jslib's code bundle.
- [ ] The Pull Request updates the `supported.json` file to contain an entry for the newly added jslib version, as in the following example:
```JSON
{
  "my-lib": [
    "1.0.2",
    // Use semantic versioning
    "{desired_version}"
  ]
}
```
- [ ] The Pull Request adds the relevant tests to the `/tests/basic.js` and `/tests/testSuite.js` files to ensure that the new version of the jslib is importable and runnable by k6.
- Merge the Pull Request once it is green. PRs adding new jslib versions do not require to get a review to be merged :rocket:. 