### PR TITLE
Make http-instrumentation-tempo and http-instrumentation-pyroscope instrumentations compatible

### DIFF
--- a/lib/http-instrumentation-pyroscope/1.0.2/index.js
+++ b/lib/http-instrumentation-pyroscope/1.0.2/index.js
@@ -4,7 +4,21 @@ const http = require("k6/http");
 const execution = require("k6/execution");
 
 function pyroBaggage(url, _, params) {
-  return { baggage: `k6.test_run_id=${__ENV.K6_CLOUDRUN_TEST_RUN_ID}, k6.scenario=${execution.scenario.name}, k6.name=${params?.tags?.name ? params.tags.name : url}` }
+  return { baggage: [
+    `k6.test_run_id=${__ENV.K6_CLOUDRUN_TEST_RUN_ID}`,
+    `k6.scenario=${execution.scenario.name}`,
+    `k6.name=${params?.tags?.name ? params.tags.name : url}`,
+  ]}
+}
+
+// mergeHeaders merges two sets of HTTP headers into a single set.
+// Whenever both sets contain a header with the same key, the values are into a list rather than replaced.
+function mergeHeaders(dst, src) {
+  for (const key in src) {
+    dst[key] = [].concat(dst[key] || [], src[key]);
+  }
+
+  return dst;
 }
 
 class Client {
@@ -57,12 +71,8 @@ function instrumentArguments(headers, ...args) {
       // event params would be nullish, we'll instantiate
       // a new object.
       if (args[1] == null) args[1] = {}
+      args[1].headers = mergeHeaders(args[1].headers || {}, headers)
 
-      let params = args[1]
-      if (params.headers == null) {
-        params.headers = {}
-      }
-      Object.assign(params.headers, headers)
       break;
   }
 

--- a/lib/http-instrumentation-pyroscope/1.0.2/index.js
+++ b/lib/http-instrumentation-pyroscope/1.0.2/index.js
@@ -1,0 +1,96 @@
+// This code specifically uses commonJS as to be faster loading in k6
+// this can be changed after https://github.com/grafana/k6/issues/3265
+const http = require("k6/http");
+const execution = require("k6/execution");
+
+function pyroBaggage(url, _, params) {
+  return { baggage: `k6.test_run_id=${__ENV.K6_CLOUDRUN_TEST_RUN_ID}, k6.scenario=${execution.scenario.name}, k6.name=${params?.tags?.name ? params.tags.name : url}` }
+}
+
+class Client {
+  generateHeaders;
+  #originalRequest;
+  #originalAsyncRequest;
+
+  constructor(generateHeaders, originalRequest = http.request, originalAsyncRequest = http.asyncRequest) {
+    if (generateHeaders == null) {
+      generateHeaders = pyroBaggage
+    }
+    this.generateHeaders = generateHeaders
+    this.#originalRequest = originalRequest;
+    this.#originalAsyncRequest = originalAsyncRequest;
+  }
+
+  // request instruments the http module's request function with tracing headers,
+  // and ensures the trace_id is emitted as part of the output's data points metadata.
+  request(method, url, ...args) {
+    let headers = this.generateHeaders(url, ...args)
+    return this.#originalRequest(method, url, ...instrumentArguments(headers, ...args));
+  }
+
+  // asyncRequest instruments the http module's asyncRequest function with tracing headers,
+  // and ensures the trace_id is emitted as part of the output's data points metadata.
+  async asyncRequest(method, url, ...args) {
+    await this.#originalAsyncRequest(method, url, ...instrumentArguments(this.generateHeaders(url, ...args), ...args));
+  }
+
+  del(url, ...args) { return this.request("DELETE", url, ...args) }
+  get(url, ...args) { return this.request("GET", url, null, ...args) }
+  head(url, ...args) { return this.request("HEAD", url, null, ...args) }
+  options(url, ...args) { return this.request("OPTIONS", url, ...args) }
+  patch(url, ...args) { return this.request("PATCH", url, ...args) }
+  post(url, ...args) { return this.request("POST", url, ...args) }
+  put(url, ...args) { return this.request("PUT", url, ...args) }
+}
+
+function instrumentArguments(headers, ...args) {
+  switch (args.length) {
+    case 0:
+      args.push(null)
+    // fallthrough to add the header
+    case 1:
+      // We only received a body argument
+      args.push({ headers: headers })
+      break;
+    default: // this handles 2 and more just in case someone provided more arguments
+      // We received both a body and a params argument. In the
+      // event params would be nullish, we'll instantiate
+      // a new object.
+      if (args[1] == null) args[1] = {}
+
+      let params = args[1]
+      if (params.headers == null) {
+        params.headers = {}
+      }
+      Object.assign(params.headers, headers)
+      break;
+  }
+
+  return args
+}
+
+function instrumentHTTP() {
+  // capture the original values late, so that they include any previously made instrumentation changes
+  const currentRequest = http.request;
+  const currentAsyncRequest = http.asyncRequest;
+
+  const client = new Client(null, currentRequest, currentAsyncRequest);
+
+  http.del = client.del.bind(client);
+  http.get = client.get.bind(client);
+  http.head = client.head.bind(client);
+  http.options = client.options.bind(client);
+  http.patch = client.patch.bind(client);
+  http.post = client.post.bind(client);
+  http.put = client.put.bind(client);
+  http.request = client.request.bind(client)
+  http.asyncRequest = client.asyncRequest.bind(client)
+}
+
+const exp = { Client: Client, instrumentHTTP: instrumentHTTP };
+
+module.exports = {
+  default: exp,
+  __esModule: true,
+  ...exp
+}

--- a/lib/http-instrumentation-tempo/1.0.1/index.js
+++ b/lib/http-instrumentation-tempo/1.0.1/index.js
@@ -1,0 +1,202 @@
+// This code specifically uses commonJS as to be faster loading in k6
+// this can be changed after https://github.com/grafana/k6/issues/3265
+const http = require("k6/http");
+const crypto = require("k6/crypto");
+const execution = require("k6/execution");
+
+const propagatorMap = {
+  "w3c": (sampler, traceID) => {
+    return {
+      "traceparent": `00-${traceID}-${randHexString(16)}-${sampler() ? "01" : "00"}`
+    }
+  },
+  "jaeger": (sampler, traceID) => {
+    return {
+      "uber-trace-id": `${traceID}:${randHexString(8)}:0:${sampler() ? "1" : "0"}`,
+    }
+  },
+}
+
+class Client {
+  #propagator;
+  #sampler;
+  #originalRequest;
+  #originalAsyncRequest;
+
+  constructor(opts, originalRequest = http.request, originalAsyncRequest = http.asyncRequest) {
+    this.configure(opts)
+    this.#originalRequest = originalRequest;
+    this.#originalAsyncRequest = originalAsyncRequest;
+  }
+
+  configure(opts) {
+    this.#sampler = newProbalisticSampler(opts.sampling);
+    this.#propagator = propagatorMap[opts.propagator];
+    if (this.#propagator == null) {
+      throw "unknown propagator: " + opts.propagator
+    }
+  }
+
+  // request instruments the http module's request function with tracing headers,
+  // and ensures the trace_id is emitted as part of the output's data points metadata.
+  request(method, url, ...args) {
+    const traceID = newTraceID()
+    const traceContextHeader = this.#propagator(this.#sampler, traceID)
+    args = instrumentArguments(traceContextHeader, ...args)
+
+    try {
+      execution.vu.metrics.metadata["trace_id"] = traceID
+      return this.#originalRequest(method, url, ...args)
+    } finally {
+      delete execution.vu.metrics.metadata["trace_id"]
+    }
+  }
+
+  // asyncRequest instruments the http module's asyncRequest function with tracing headers,
+  // and ensures the trace_id is emitted as part of the output's data points metadata.
+  async asyncRequest(method, url, ...args) {
+    const traceID = newTraceID()
+    const traceContextHeader = this.#propagator(this.#sampler, traceID)
+    args = instrumentArguments(traceContextHeader, ...args)
+
+    let promise;
+    try {
+      execution.vu.metrics.metadata["trace_id"] = traceID
+      promise = this.#originalAsyncRequest(method, url, ...args)
+    } finally {
+      delete execution.vu.metrics.metadata["trace_id"]
+    }
+
+    return await promise;
+  }
+
+  del(url, ...args) { return this.request("DELETE", url, ...args) }
+  get(url, ...args) { return this.request("GET", url, null, ...args) }
+  head(url, ...args) { return this.request("HEAD", url, null, ...args) }
+  options(url, ...args) { return this.request("OPTIONS", url, ...args) }
+  patch(url, ...args) { return this.request("PATCH", url, ...args) }
+  post(url, ...args) { return this.request("POST", url, ...args) }
+  put(url, ...args) { return this.request("PUT", url, ...args) }
+}
+
+function longToByteArray(long) {
+  var byteArray = new Uint8Array(8)
+
+  for (var index = byteArray.byteLength; index >= 0; index--) {
+    const byte = long % 256
+    byteArray[index] = byte
+    long = (long-byte)/256;
+    if (long < 1) {
+      break
+    }
+  }
+
+  return byteArray;
+}
+function instrumentArguments(traceContext, ...args) {
+  switch (args.length) {
+    case 0:
+      args.push(null)
+    // fallthrough to add the header
+    case 1:
+      // We only received a body argument
+      args.push({ headers: traceContext })
+      break;
+    default: // this handles 2 and more just in case someone provided more arguments
+      // We received both a body and a params argument. In the
+      // event params would be nullish, we'll instantiate
+      // a new object.
+      if (args[1] == null) args[1] = {}
+
+      let params = args[1]
+      if (params.headers == null) {
+        params.headers = {}
+      }
+      Object.assign(params.headers, traceContext)
+      break;
+  }
+
+  return args
+}
+
+
+function newTraceID() {
+  let result = "dc0718" // prefix for k6
+
+  // add nanoseconds
+  let now = Date.now()
+  const ns = longToByteArray(now * 1e6) // this is very likely ... loosy
+  let n = 3
+  let i = 0
+  for (; i < ns.byteLength; i++) { // skip leading zeros
+    if (ns[i] == 0) continue;
+    break;
+  }
+  for (; i < ns.byteLength; i++) {
+    result += ns[i].toString(16).padStart(2, "0")
+    n++;
+  }
+
+  // pad with random
+  let random = new Uint8Array(crypto.randomBytes(16 - n));
+  for (i=0; i < random.byteLength; i++) {
+    result += random[i].toString(16).padStart(2, "0")
+    n++;
+  }
+
+  return result
+}
+
+function newProbalisticSampler(samplingRate) {
+  if (samplingRate < 0 || samplingRate > 1) {
+    throw "sampling rate must be between 0.0 and 1.0"
+  }
+  if (typeof samplingRate == 'undefined') {
+    samplingRate = 1
+
+  }
+  switch (samplingRate) {
+    case 0:
+      return () => false
+    case 1:
+      return () => true
+    default:
+      return () => Math.random() < samplingRate
+  }
+}
+
+const digits = "0123456789abcdef";
+
+function randHexString(n) {
+  let result = '';
+  for (let i = 0; i < n; ++i) {
+    result += digits[Math.floor(16 * Math.random())];
+  }
+  return result;
+}
+
+function instrumentHTTP(opts) {
+  // capture the original values late, so that they include any previously made instrumentation changes
+  const currentRequest = http.request;
+  const currentAsyncRequest = http.asyncRequest;
+
+  const client = new Client(opts, currentRequest, currentAsyncRequest);
+
+  http.del = client.del.bind(client);
+  http.get = client.get.bind(client);
+  http.head = client.head.bind(client);
+  http.options = client.options.bind(client);
+  http.patch = client.patch.bind(client);
+  http.post = client.post.bind(client);
+  http.put = client.put.bind(client);
+  http.request = client.request.bind(client)
+  http.asyncRequest = client.asyncRequest.bind(client)
+}
+
+const exp = { Client: Client, instrumentHTTP: instrumentHTTP };
+
+module.exports = {
+  default: exp,
+  __esModule: true,
+  ...exp
+}

--- a/lib/index.html
+++ b/lib/index.html
@@ -636,7 +636,7 @@ export default function() {
       <td><a href="https://grafana.com/docs/k6/latest/javascript-api/jslib/aws">https://grafana.com/docs/k6/latest/javascript-api/jslib/aws</a></td>
     </tr><tr>
       <td>http-instrumentation-pyroscope</td>
-      <td><a target="_blank" href="https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js">1.0.0</a>, <a target="_blank" href="https://jslib.k6.io/http-instrumentation-pyroscope/1.0.1/index.js">1.0.1</a></td>
+      <td><a target="_blank" href="https://jslib.k6.io/http-instrumentation-pyroscope/1.0.0/index.js">1.0.0</a>, <a target="_blank" href="https://jslib.k6.io/http-instrumentation-pyroscope/1.0.1/index.js">1.0.1</a>, <a target="_blank" href="https://jslib.k6.io/http-instrumentation-pyroscope/1.0.2/index.js">1.0.2</a></td>
       <td><a href="https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-pyroscope/">https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-pyroscope/</a></td>
     </tr><tr>
       <td>http-instrumentation-tempo</td>

--- a/lib/index.html
+++ b/lib/index.html
@@ -640,7 +640,7 @@ export default function() {
       <td><a href="https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-pyroscope/">https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-pyroscope/</a></td>
     </tr><tr>
       <td>http-instrumentation-tempo</td>
-      <td><a target="_blank" href="https://jslib.k6.io/http-instrumentation-tempo/1.0.0/index.js">1.0.0</a></td>
+      <td><a target="_blank" href="https://jslib.k6.io/http-instrumentation-tempo/1.0.0/index.js">1.0.0</a>, <a target="_blank" href="https://jslib.k6.io/http-instrumentation-tempo/1.0.1/index.js">1.0.1</a></td>
       <td><a href="https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-tempo/">https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-tempo/</a></td>
     </tr>
     </table>

--- a/supported.json
+++ b/supported.json
@@ -85,7 +85,7 @@
     "docs-url": "https://grafana.com/docs/k6/latest/javascript-api/jslib/aws"
   },
   "http-instrumentation-pyroscope": {
-    "versions": ["1.0.0", "1.0.1"],
+    "versions": ["1.0.0", "1.0.1", "1.0.2"],
     "docs-url": "https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-pyroscope/"
   },
   "http-instrumentation-tempo": {

--- a/supported.json
+++ b/supported.json
@@ -89,7 +89,7 @@
     "docs-url": "https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-pyroscope/"
   },
   "http-instrumentation-tempo": {
-    "versions": ["1.0.0"],
+    "versions": ["1.0.0", "1.0.1"],
     "docs-url": "https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-tempo/"
   }
 }

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -21,14 +21,6 @@ import {
   tagWithCurrentStageProfile,
 } from '../lib/k6-utils/1.4.0/index.js'
 
-import pyroscope from "../lib/http-instrumentation-pyroscope/1.0.2/index.js"
-import tempo from "../lib/http-instrumentation-tempo/1.0.1/index.js"
-
-pyroscope.instrumentHTTP()
-tempo.instrumentHTTP({
-  propagator: "w3c",
-})
-
 initContractPlugin(chai)
 
 function testJsonPath() {

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -21,8 +21,10 @@ import {
   tagWithCurrentStageProfile,
 } from '../lib/k6-utils/1.4.0/index.js'
 
-import pyroscope from "../lib/http-instrumentation-pyroscope/1.0.0/index.js"
+import pyroscope from "../lib/http-instrumentation-pyroscope/1.0.2/index.js"
 import tempo from "../lib/http-instrumentation-tempo/1.0.0/index.js"
+
+pyroscope.instrumentHTTP()
 
 initContractPlugin(chai)
 

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -22,9 +22,12 @@ import {
 } from '../lib/k6-utils/1.4.0/index.js'
 
 import pyroscope from "../lib/http-instrumentation-pyroscope/1.0.2/index.js"
-import tempo from "../lib/http-instrumentation-tempo/1.0.0/index.js"
+import tempo from "../lib/http-instrumentation-tempo/1.0.1/index.js"
 
 pyroscope.instrumentHTTP()
+tempo.instrumentHTTP({
+  propagator: "w3c",
+})
 
 initContractPlugin(chai)
 

--- a/tests/instrumentation-pyroscope.js
+++ b/tests/instrumentation-pyroscope.js
@@ -1,0 +1,60 @@
+import pyroscope from '../lib/http-instrumentation-pyroscope/1.0.2/index.js'
+import { check } from 'k6'
+
+function validateBaggageHeader(headers) {
+    if (check(headers, { 'has baggage header': (headers) => headers['Baggage'] != null })) {
+        check(headers, {
+            'baggage header contains test run id': (headers) => headers['Baggage'].includes('k6.test_run_id'),
+            'baggage header contains scenario': (headers) => headers['Baggage'].includes('k6.scenario'),
+            'baggage header contains name': (headers) => headers['Baggage'].includes('k6.name'),
+        })
+    }
+}
+
+function testPyroscopeNoBody() {
+    const client = new pyroscope.Client()
+    const res = client.request('GET', 'https://httpbin.test.k6.io/anything')
+    const req = JSON.parse(res.body)
+
+    validateBaggageHeader(req.headers)
+}
+
+function testPyroscopeWithBody() {
+    const client = new pyroscope.Client()
+    const res = client.request('GET', 'https://httpbin.test.k6.io/anything', 'hello')
+    const req = JSON.parse(res.body)
+
+    validateBaggageHeader(req.headers)
+}
+
+function testPyroscopeRequestWithParams() {
+    const client = new pyroscope.Client()
+    const res = client.request(
+        'GET',
+        'https://httpbin.test.k6.io/anything',
+        null,
+        {
+            headers: {
+                baggage: 'foo=bar',
+                'X-Test': 'test',
+            },
+            cookies: { 'X-Test': { value: 'test', replace: true } },
+        },
+    )
+    const req = JSON.parse(res.body)
+
+    check(req, {
+        'contains cookies': (req) => req.headers['Cookie'] === 'X-Test=test',
+        'contains original headers': (req) => req.headers['X-Test'] === 'test',
+        'baggage header has original value': (req) => req.headers['Baggage'].includes('foo=bar'),
+    })
+
+    validateBaggageHeader(req.headers)
+}
+
+export {
+  testPyroscopeNoBody,
+  testPyroscopeWithBody,
+  testPyroscopeRequestWithParams,
+}
+

--- a/tests/instrumentation-tempo.js
+++ b/tests/instrumentation-tempo.js
@@ -1,0 +1,38 @@
+import tempo from '../lib/http-instrumentation-tempo/1.0.1/index.js'
+import { check } from 'k6'
+
+function testTempoW3CPropagator() {
+    const client = new tempo.Client({
+        propagator: 'w3c',
+    })
+
+    const res = client.request('GET', 'https://httpbin.test.k6.io/anything')
+    const req = JSON.parse(res.body)
+
+    if (check(req, { 'contains traceparent header': (req) => req.headers['Traceparent'] != null })) {
+        check(req, {
+            'traceparent header is valid': (req) => req.headers['Traceparent'].match(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[01]{2}$/),
+        })
+    }
+}
+
+function testTempoJaegerPropagator() {
+    const client = new tempo.Client({
+        propagator: 'jaeger',
+    })
+
+    const res = client.request('GET', 'https://httpbin.test.k6.io/anything')
+    const req = JSON.parse(res.body)
+
+    if (check(req, { 'contains uber-trace-id header': (req) => req.headers['Uber-Trace-Id'] != null })) {
+        console.log(req.headers['Uber-Trace-Id'])
+        check(req, {
+            'uber-trace-id header is valid': (req) => req.headers['Uber-Trace-Id'].match(/^[0-9a-f]{32}:[0-9a-f]{8}:0:[01]$/),
+        })
+    }
+}
+
+export {
+    testTempoW3CPropagator,
+    testTempoJaegerPropagator,
+}

--- a/tests/testSuite.js
+++ b/tests/testSuite.js
@@ -7,6 +7,11 @@ import { CrocFlow } from './crocFlow.js'
 import { URLWebAPI } from './url.js'
 import { testAWS } from './aws.js'
 import {
+  testPyroscopeNoBody,
+  testPyroscopeWithBody,
+  testPyroscopeRequestWithParams,
+} from './instrumentation-pyroscope.js'
+import {
   testJsonPath,
   testFormurlencoded,
   testPapaparse,
@@ -49,6 +54,9 @@ const testCases = [
   testNormalDistributionStages,
   testRandomString,
   testAWS,
+  testPyroscopeNoBody,
+  testPyroscopeWithBody,
+  testPyroscopeRequestWithParams,
 ]
 
 export const options = {

--- a/tests/testSuite.js
+++ b/tests/testSuite.js
@@ -31,6 +31,7 @@ import {
   testTagWithCurrentStageProfile,
   testk6chaijs,
   testk6chaijscontracts,
+  testHTTPInstrumentation,
 } from './basic.js'
 
 let testCasesOK = new Rate('test_case_ok')
@@ -63,6 +64,7 @@ const testCases = [
   testPyroscopeRequestWithParams,
   testTempoW3CPropagator,
   testTempoJaegerPropagator,
+  testHTTPInstrumentation,
 ]
 
 export const options = {

--- a/tests/testSuite.js
+++ b/tests/testSuite.js
@@ -12,6 +12,10 @@ import {
   testPyroscopeRequestWithParams,
 } from './instrumentation-pyroscope.js'
 import {
+  testTempoW3CPropagator,
+  testTempoJaegerPropagator,
+} from './instrumentation-tempo.js'
+import {
   testJsonPath,
   testFormurlencoded,
   testPapaparse,
@@ -57,6 +61,8 @@ const testCases = [
   testPyroscopeNoBody,
   testPyroscopeWithBody,
   testPyroscopeRequestWithParams,
+  testTempoW3CPropagator,
+  testTempoJaegerPropagator,
 ]
 
 export const options = {


### PR DESCRIPTION
## Description

This PR introduces new versions for Tempo and Pyroscope instrumentation libraries that are compatible with each other. The core change is that `http.request` and `http.asyncRequest` in both libraries are now being captured at during the `instrumentHTTP()` call instead of during the import phase, which ensures that instrumented code wraps the latest, potentially already patched version of the method.

Update: following the discussion with @mstoykov I've added another fix for the Pyroscope instrumentation library, that now preserves the values of `baggage` header provided to `request` and appends k6 metadata to it instead of overriding.

Closes #151 

- [x] Use a meaningful title for the Pull Request. Include the name of the jslib added/modified.
- [x] Fill the description section of the Pull Request. 
- [x] Test the change in your code, and ensure the `npm run test` command succeeds.
- [x] Run `yarn run generate-homepage` locally and verify the new homepage `/lib/index.html` file looks legit.
- [x] The Pull Request is labeled with the `version bump` label.
- [x] The Pull Request adds a `/lib/{jslib_name}/{desired_version}` folder.
- [x] The Pull Request adds a `/lib/{jslib_name}/{desired_version}/index.js` file containing the jslib's code bundle.
- [x] The Pull Request updates the `supported.json` file to contain an entry for the newly added jslib version
- [x] The Pull Request adds the relevant tests to the `/tests/basic.js` and `/tests/testSuite.js` files to ensure that the new version of the jslib is importable and runnable by k6.
- Merge the Pull Request once it is green. PRs adding new jslib versions do not require to get a review to be merged :rocket:. 