### PR TITLE
chore: prepare workflows for get-vault-secrets v2

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -17,19 +17,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         
-      - id: get-secrets 
+      - id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           vault_instance: dev
+          export_env: false
           # arn:.../k6-jslib-uploader-role
           repo_secrets: |
-            IAM_ROLE_ARN=deploy:uploader-iam-role 
+            IAM_ROLE_ARN=deploy:uploader-iam-role
 
       - name: aws-auth
         uses: grafana/shared-workflows/actions/aws-auth@85022085ed5314601c05d10e846de56bdd71e369 # aws-auth/v1.0.3
         with:
           aws-region: 'us-west-1'
-          role-arn: '${{ env.IAM_ROLE_ARN }}'
+          role-arn: '${{ fromJSON(steps.get-secrets.outputs.secrets).IAM_ROLE_ARN }}'
           set-creds-in-environment: true
 
       - name: Deploy lib to s3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,17 +21,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
+          export_env: false
           # arn:.../k6-jslib-uploader-role
           repo_secrets: |
-            IAM_ROLE_ARN=deploy:uploader-iam-role 
+            IAM_ROLE_ARN=deploy:uploader-iam-role
 
       - name: aws-auth
         uses: grafana/shared-workflows/actions/aws-auth@85022085ed5314601c05d10e846de56bdd71e369 # aws-auth/v1.0.3
         with:
           aws-region: 'us-west-1'
-          role-arn: '${{ env.IAM_ROLE_ARN }}'
+          role-arn: '${{ fromJSON(steps.get-secrets.outputs.secrets).IAM_ROLE_ARN }}'
           set-creds-in-environment: true
 
       - name: Deploy lib to s3


### PR DESCRIPTION
## Description

Opts the `deploy` and `deploy-dev` workflows' `get-vault-secrets` usage into the upcoming v2 behavior: sets `export_env: false`, ensures each step has an explicit `id`, and reads `IAM_ROLE_ARN` from the step's `secrets` output via `fromJSON(...)` instead of `env.IAM_ROLE_ARN`.

v2 of `grafana/shared-workflows/actions/get-vault-secrets` will no longer auto-export retrieved secrets as environment variables. This change makes the workflows forward-compatible before v2 lands.

_(This is a CI-only change; the jslib add/version-bump checklist items in the template don't apply.)_